### PR TITLE
Including additional parameters to Hub error responses

### DIFF
--- a/websubhub-ballerina/errors.bal
+++ b/websubhub-ballerina/errors.bal
@@ -14,36 +14,39 @@
 // specific language governing permissions and limitations
 // under the License.
 
+# Represents a websubhub distinct error
+public type Error distinct error<CommonResponse>;
+
 # Error Type representing the errors in topic registration action
-public type TopicRegistrationError distinct error;
+public type TopicRegistrationError distinct Error;
 
 # Error Type representing the errors in topic unregistration action
-public type TopicDeregistrationError distinct error;
+public type TopicDeregistrationError distinct Error;
 
 # Error Type representing the errors in subscription request
-public type BadSubscriptionError distinct error;
+public type BadSubscriptionError distinct Error;
 
 # Error Type representing the internal errors in subscription action
-public type InternalSubscriptionError distinct error;
+public type InternalSubscriptionError distinct Error;
 
 # Error Type representing the validation errors in subscription request body
-public type SubscriptionDeniedError distinct error;
+public type SubscriptionDeniedError distinct Error;
 
 # Error Type representing the errors in unsubscription request
-public type BadUnsubscriptionError distinct error;
+public type BadUnsubscriptionError distinct Error;
 
 # Error Type representing the internal errors in unsubscription action
-public type InternalUnsubscriptionError distinct error;
+public type InternalUnsubscriptionError distinct Error;
 
 # Error Type representing the validation errors in unsubscription request body
-public type UnsubscriptionDeniedError distinct error;
+public type UnsubscriptionDeniedError distinct Error;
 
 # Error Type representing the errors in content update request
-public type UpdateMessageError distinct error;
+public type UpdateMessageError distinct Error;
 
 # Error Type representing the subscriber ending the subscription 
 # by sending `HTTP 410` for content delivery response
-public type SubscriptionDeletedError distinct error;
+public type SubscriptionDeletedError distinct Error;
 
 # Error Type representing the internal errors in content distribution
-public type ContentDeliveryError distinct error;
+public type ContentDeliveryError distinct Error;

--- a/websubhub-ballerina/hub_listener.bal
+++ b/websubhub-ballerina/hub_listener.bal
@@ -15,6 +15,7 @@
 // under the License.
 
 import ballerina/http;
+import ballerina/log;
 
 # Represents a Service listener endpoint.
 public class Listener {
@@ -46,6 +47,10 @@ public class Listener {
     # + name - The path of the Service to be hosted
     # + return - An `error`, if an error occurred during the service attaching process
     public isolated function attach(Service s, string[]|string? name = ()) returns error? {
+        if (self.listenerConfig.secureSocket is ()) {
+            log:print("HTTPS is recommended but using HTTP");
+        }
+
         string hubUrl = self.retrieveHubUrl(name);
         // todo implement to retrieve hub-lease-seconds via annotation configuration
         self.httpService = new(s, hubUrl, self.defaultHubLeaseSeconds);

--- a/websubhub-ballerina/tests/additional_error_details_test.bal
+++ b/websubhub-ballerina/tests/additional_error_details_test.bal
@@ -1,0 +1,194 @@
+// Copyright (c) 2021 WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+//
+// WSO2 Inc. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import ballerina/log;
+import ballerina/http;
+import ballerina/test;
+import ballerina/regex;
+
+listener Listener hubListenerToAdditionalErrorDetails = new(9093);
+
+var hubServiceToTestAdditionalErrorDetails = service object {
+
+    remote function onRegisterTopic(TopicRegistration message)
+                                returns TopicRegistrationError {
+        return error TopicRegistrationError("Topic registration failed!",
+                        body = { "hub.additional.details": "Feature is not supported in the hub"});
+    }
+
+    remote function onDeregisterTopic(TopicDeregistration message)
+                        returns TopicDeregistrationError {
+        return error TopicDeregistrationError("Topic deregistration failed!");
+    }
+
+    remote function onUpdateMessage(UpdateMessage msg)
+               returns UpdateMessageError {
+        return error UpdateMessageError("Error in accessing content", 
+                     body = { "hub.additiona.details": "Content update failed!"});
+    }
+    
+    remote function onSubscription(Subscription msg)
+                returns SubscriptionAccepted|BadSubscriptionError|InternalSubscriptionError {
+        SubscriptionAccepted successResult = {
+                body: <map<string>>{
+                       isSuccess: "true"
+                    }
+            };
+        if (msg.hubTopic == "test") {
+            return successResult;
+        } else {
+            return error BadSubscriptionError("Bad subscription");
+        }
+    }
+
+    remote function onSubscriptionValidation(Subscription msg)
+                returns SubscriptionDeniedError? {
+        if (msg.hubTopic != "test") {
+            return error SubscriptionDeniedError("Denied subscription for topic 'test1'");
+        }
+    }
+
+    remote function onSubscriptionIntentVerified(VerifiedSubscription msg) {
+        log:print("Subscription Intent verified invoked!");
+        isIntentVerified = true;
+    }
+
+    remote function onUnsubscription(Unsubscription msg)
+               returns UnsubscriptionAccepted|BadUnsubscriptionError|InternalUnsubscriptionError {
+        if (msg.hubTopic == "test") {
+            UnsubscriptionAccepted successResult = {
+                body: <map<string>>{
+                       isSuccess: "true"
+                    }
+            };
+            return successResult;
+        } else {
+            return error BadUnsubscriptionError("Denied unsubscription for topic '" + <string> msg.hubTopic + "'");
+        }
+    }
+
+    remote function onUnsubscriptionValidation(Unsubscription msg)
+                returns UnsubscriptionDeniedError? {
+        if (msg.hubTopic != "test") {
+            return error UnsubscriptionDeniedError("Denied subscription for topic 'test1'");
+        }
+        return ();
+    }
+
+    remote function onUnsubscriptionIntentVerified(VerifiedUnsubscription msg){
+        log:print("Unsubscription Intent verified invoked!");
+    }
+};
+
+@test:BeforeGroups { value:["additional-error-details"] }
+function beforeAdditionalErrorDetailsTest() {
+    checkpanic hubListenerToAdditionalErrorDetails.attach(hubServiceToTestAdditionalErrorDetails, "websubhub");
+}
+
+@test:AfterGroups { value:["additional-error-details"] }
+function afterAdditionalErrorDetailsTest() {
+    checkpanic hubListenerToAdditionalErrorDetails.gracefulStop();
+}
+
+http:Client errorDetailsTestClientEp = checkpanic new("http://localhost:9093/websubhub");
+
+@test:Config {
+    groups: ["additional-error-details"]
+}
+function testRegistrationFailureErrorDetails() returns @tainted error? {
+    http:Request request = new;
+    request.setTextPayload("hub.mode=register&hub.topic=test1", "application/x-www-form-urlencoded");
+
+    var response = check errorDetailsTestClientEp->post("/", request);
+    if (response is http:Response) {
+        test:assertEquals(response.statusCode, 200);
+        var payload = response.getTextPayload();
+        if (payload is error) {
+            test:assertFail("Could not retrieve response body for topic-registration failure");
+        } else {
+            var responseBody = decodeResponseBody(payload);
+            log:print("Retrieved error-response for topic registration failure ", responseBody = responseBody);
+            test:assertEquals(responseBody["hub.mode"], "denied");
+            test:assertEquals(responseBody["hub.reason"], "Topic registration failed!");
+            test:assertEquals(responseBody["hub.additional.details"], "Feature is not supported in the hub");
+        }
+    } else {
+        test:assertFail("Topic registration test failed");
+    }
+}
+
+@test:Config {
+    groups: ["additional-error-details"]
+}
+function testDeregistrationFailureErrorDetails() returns @tainted error? {
+    http:Request request = new;
+    request.setTextPayload("hub.mode=deregister&hub.topic=test1", "application/x-www-form-urlencoded");
+
+    var response = check errorDetailsTestClientEp->post("/", request);
+    if (response is http:Response) {
+        test:assertEquals(response.statusCode, 200);
+        var payload = response.getTextPayload();
+        if (payload is error) {
+            test:assertFail("Could not retrieve response body for topic-deregistration failure");
+        } else {
+            var responseBody = decodeResponseBody(payload);
+            log:print("Retrieved error-response for topic de-registration failure ", responseBody = responseBody);
+            test:assertEquals(responseBody["hub.mode"], "denied");
+            test:assertEquals(responseBody["hub.reason"], "Topic deregistration failed!");
+        }
+    } else {
+        test:assertFail("Topic deregistration test failed");
+    }
+}
+
+@test:Config {
+    groups: ["additional-error-details"]
+}
+function testUpdateMessageErrorDetails() returns @tainted error? {
+    http:Request request = new;
+    request.setTextPayload("hub.mode=publish&hub.topic=test", "application/x-www-form-urlencoded");
+
+    var response = check errorDetailsTestClientEp->post("/", request);
+    if (response is http:Response) {
+        test:assertEquals(response.statusCode, 200);
+        var payload = response.getTextPayload();
+        if (payload is error) {
+            test:assertFail("Could not retrieve response body for content update");
+        } else {
+            var responseBody = decodeResponseBody(payload);
+            log:print("Retrieved error-response for content-update failure ", responseBody = responseBody);
+            test:assertEquals(responseBody["hub.mode"], "denied");
+            test:assertEquals(responseBody["hub.reason"], "Error in accessing content");
+        }        
+    } else {
+        test:assertFail("Content update test failed");
+    }
+}
+
+isolated function decodeResponseBody(string payload) returns map<string> {
+    map<string> body = {};
+    if (payload.length() > 0) {
+        string[] splittedPayload = regex:split(payload, "&");
+        foreach var bodyPart in splittedPayload {
+            var responseComponent =  regex:split(bodyPart, "=");
+            if (responseComponent.length() == 2) {
+                body[responseComponent[0]] = responseComponent[1];
+            }
+        }
+        return body;
+    }
+    return body;
+} 

--- a/websubhub-ballerina/tests/basic_hub_test.bal
+++ b/websubhub-ballerina/tests/basic_hub_test.bal
@@ -204,47 +204,6 @@ function testDeregistrationFailure() returns @tainted error? {
     }
 }
 
-service /subscriber on new http:Listener(9091) {
-
-    resource function get .(http:Caller caller, http:Request req)
-            returns error? {
-        map<string[]> payload = req.getQueryParams();
-        string[] hubMode = <string[]> payload["hub.mode"];
-        if (hubMode[0] == "denied") {
-            io:println("Subscriber Validation failed get", payload);
-            isValidationFailed = true;
-            check caller->respond("");
-        } else {
-            string[] challengeArray = <string[]> payload["hub.challenge"];
-            check caller->respond(challengeArray[0]);
-        }
-    }
-
-    resource function post .(http:Caller caller, http:Request req)
-            returns error? {
-        check caller->respond();
-    }
-
-    resource function get unsubscribe(http:Caller caller, http:Request req)
-            returns error? {
-        map<string[]> payload = req.getQueryParams();
-        string[] hubMode = <string[]> payload["hub.mode"];
-        if (hubMode[0] == "denied") {
-            io:println("Unsubscription Validation failed get", payload);
-            isValidationFailed = true;
-            check caller->respond("");
-        } else {
-            string[] challengeArray = <string[]> payload["hub.challenge"];
-            check caller->respond(challengeArray[0]);
-        }
-    }
-
-    resource function post unsubscribe(http:Caller caller, http:Request req)
-            returns error? {
-        check caller->respond();
-    }
-}
-
 @test:Config {
 }
 function testSubscriptionFailure() returns @tainted error? {

--- a/websubhub-ballerina/tests/hub_client_test.bal
+++ b/websubhub-ballerina/tests/hub_client_test.bal
@@ -18,7 +18,7 @@ import ballerina/io;
 import ballerina/http;
 import ballerina/test;
 
-service /callback on new http:Listener(9092) {
+service /callback on new http:Listener(9094) {
     resource function post success(http:Caller caller, http:Request req) {
         io:println("Hub Content Distribution message received : ", req.getTextPayload());
         printHeaders(req);
@@ -61,7 +61,7 @@ isolated function retrieveSubscriptionMsg(string callbackUrl) returns Subscripti
 @test:Config {
 }
 function testTextContentDelivery() returns @tainted error? {
-    Subscription subscriptionMsg = retrieveSubscriptionMsg("http://localhost:9092/callback/success");
+    Subscription subscriptionMsg = retrieveSubscriptionMsg("http://localhost:9094/callback/success");
 
     HubClient hubClientEP = checkpanic new(subscriptionMsg);
 
@@ -79,7 +79,7 @@ function testTextContentDelivery() returns @tainted error? {
 @test:Config {
 }
 function testJsonContentDelivery() returns @tainted error? {
-    Subscription subscriptionMsg = retrieveSubscriptionMsg("http://localhost:9092/callback/success");
+    Subscription subscriptionMsg = retrieveSubscriptionMsg("http://localhost:9094/callback/success");
 
     HubClient hubClientEP = checkpanic new(subscriptionMsg);
     
@@ -102,7 +102,7 @@ function testJsonContentDelivery() returns @tainted error? {
 @test:Config {
 }
 function testXmlContentDelivery() returns @tainted error? {
-    Subscription subscriptionMsg = retrieveSubscriptionMsg("http://localhost:9092/callback/success");
+    Subscription subscriptionMsg = retrieveSubscriptionMsg("http://localhost:9094/callback/success");
 
     HubClient hubClientEP = checkpanic new(subscriptionMsg);
     
@@ -125,7 +125,7 @@ function testXmlContentDelivery() returns @tainted error? {
 @test:Config {
 }
 function testByteArrayContentDelivery() returns @tainted error? {
-    Subscription subscriptionMsg = retrieveSubscriptionMsg("http://localhost:9092/callback/success");
+    Subscription subscriptionMsg = retrieveSubscriptionMsg("http://localhost:9094/callback/success");
 
     HubClient hubClientEP = checkpanic new(subscriptionMsg);
     
@@ -144,7 +144,7 @@ function testByteArrayContentDelivery() returns @tainted error? {
 @test:Config {
 }
 function testSubscriptionDeleted() returns @tainted error? {
-    Subscription subscriptionMsg = retrieveSubscriptionMsg("http://localhost:9092/callback/deleted");
+    Subscription subscriptionMsg = retrieveSubscriptionMsg("http://localhost:9094/callback/deleted");
 
     HubClient hubClientEP = checkpanic new(subscriptionMsg);
 

--- a/websubhub-ballerina/tests/test_init.bal
+++ b/websubhub-ballerina/tests/test_init.bal
@@ -27,7 +27,7 @@ var simpleSubscriber = service object {
         map<string[]> payload = req.getQueryParams();
         string[] hubMode = <string[]> payload["hub.mode"];
         if (hubMode[0] == "denied") {
-            log:print("Subscriber Validation failed ", payload.toString());
+            log:print("Subscriber Validation failed ", retrievedPayload = payload);
             isValidationFailed = true;
             check caller->respond("");
         } else {
@@ -46,7 +46,7 @@ var simpleSubscriber = service object {
         map<string[]> payload = req.getQueryParams();
         string[] hubMode = <string[]> payload["hub.mode"];
         if (hubMode[0] == "denied") {
-            log:print("Unsubscription Validation failed ", payload.toString());
+            log:print("Unsubscription Validation failed ", retrievedPayload = payload);
             isValidationFailed = true;
             check caller->respond("");
         } else {

--- a/websubhub-ballerina/tests/test_init.bal
+++ b/websubhub-ballerina/tests/test_init.bal
@@ -1,0 +1,72 @@
+// Copyright (c) 2021 WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+//
+// WSO2 Inc. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import ballerina/test;
+import ballerina/http;
+import ballerina/log;
+
+listener http:Listener simpleSubscriberListener = new (9191);
+
+var simpleSubscriber = service object {
+
+    resource function get .(http:Caller caller, http:Request req)
+            returns error? {
+        map<string[]> payload = req.getQueryParams();
+        string[] hubMode = <string[]> payload["hub.mode"];
+        if (hubMode[0] == "denied") {
+            log:print("Subscriber Validation failed ", payload.toString());
+            isValidationFailed = true;
+            check caller->respond("");
+        } else {
+            string[] challengeArray = <string[]> payload["hub.challenge"];
+            check caller->respond(challengeArray[0]);
+        }
+    }
+
+    resource function post .(http:Caller caller, http:Request req)
+            returns error? {
+        check caller->respond();
+    }
+
+    resource function get unsubscribe(http:Caller caller, http:Request req)
+            returns error? {
+        map<string[]> payload = req.getQueryParams();
+        string[] hubMode = <string[]> payload["hub.mode"];
+        if (hubMode[0] == "denied") {
+            log:print("Unsubscription Validation failed ", payload.toString());
+            isValidationFailed = true;
+            check caller->respond("");
+        } else {
+            string[] challengeArray = <string[]> payload["hub.challenge"];
+            check caller->respond(challengeArray[0]);
+        }
+    }
+
+    resource function post unsubscribe(http:Caller caller, http:Request req)
+            returns error? {
+        check caller->respond();
+    }
+};
+
+@test:BeforeSuite
+function beforeSuiteFunc() {
+    checkpanic simpleSubscriberListener.attach(simpleSubscriber, "subscriber");
+}
+
+@test:AfterSuite { }
+function afterSuiteFunc() {
+    checkpanic simpleSubscriberListener.gracefulStop();
+}

--- a/websubhub-ballerina/tests/websub_publisher_test.bal
+++ b/websubhub-ballerina/tests/websub_publisher_test.bal
@@ -17,7 +17,7 @@
 import ballerina/io;
 import ballerina/test;
 
-listener Listener testListener = new(9191);
+listener Listener testListener = new(9092);
 
 service /websubhub on testListener {
 
@@ -71,7 +71,7 @@ service /websubhub on testListener {
     }
 }
 
-PublisherClient websubHubClientEP = checkpanic new ("http://localhost:9191/websubhub");
+PublisherClient websubHubClientEP = checkpanic new ("http://localhost:9092/websubhub");
 
 @test:Config{}
 public function testPublisherRegisterSuccess() {


### PR DESCRIPTION
## Purpose
> With this PR there will be support to include additional details to the errors returned from the `websubhub:Service`.
> Now developers can integrate additional details to `websubhub:Service` error responses as follows.
```ballerina
service /websubhub on websubhub:Listener(9091) {

    remote function onRegisterTopic(websubhub:TopicRegistration message)
                                returns websubhub:TopicRegistrationSuccess|websubhub:TopicRegistrationError {
        if (message.topic == "https://sub.topic.com") {
            websubhub:TopicRegistrationSuccess successResult = {
                body: <map<string>>{
                       isSuccess: "true"
                    }
            };
            return successResult;
        } else {
           return error websubhub:TopicRegistrationError("Topic registration failed!",
                        headers = { "Content-Encoding" :  "gzip" },
                        body = { "hub.additional.details": "Feature is not supported in the hub"});
        }
    }

}
```
> Additional parameters which are provided to the error types will be reflected in corresponding responses. 
> Content-Type for the response-body will be `application/x-www-form-urlencoded`.

Fixes: [#945](https://github.com/ballerina-platform/ballerina-standard-library/issues/945)