### PR TITLE
Support mime content delivery

### DIFF
--- a/websubhub-ballerina/commons.bal
+++ b/websubhub-ballerina/commons.bal
@@ -14,6 +14,7 @@
 // specific language governing permissions and limitations
 // under the License.
 import ballerina/http;
+import ballerina/mime;
 
 # Parameter `hub.mode` representing the mode of the request from hub to subscriber or subscriber to hub.
 const string HUB_MODE = "hub.mode";
@@ -118,7 +119,7 @@ type CommonResponse record {|
 public type ContentDistributionMessage record {|
     map<string|string[]>? headers = ();
     string? contentType = ();
-    map<string>|json|xml|string|byte[] content;
+    map<string>|json|xml|string|byte[]|mime:Entity[] content;
 |};
 
 # Record to represent the successful WebSub content delivery
@@ -212,7 +213,7 @@ public type UpdateMessage record {
     MessageType msgType;
     string hubTopic;
     string contentType;
-    string|byte[]|json|xml|map<string>? content;
+    string|byte[]|json|xml|map<string>?|mime:Entity[] content;
 };
 
 # Record to represent Topic Registration success

--- a/websubhub-ballerina/http_service.bal
+++ b/websubhub-ballerina/http_service.bal
@@ -91,7 +91,7 @@ service class HttpService {
                     params = reqFormParamMap is map<string> ? reqFormParamMap : {};
                 }
             }
-            mime:APPLICATION_JSON|mime:APPLICATION_XML|mime:APPLICATION_OCTET_STREAM|mime:TEXT_PLAIN => {
+            mime:APPLICATION_JSON|mime:APPLICATION_XML|mime:APPLICATION_OCTET_STREAM|mime:TEXT_PLAIN|mime:MULTIPART_FORM_DATA|mime:MULTIPART_MIXED|mime:MULTIPART_ALTERNATIVE => {
                 string[] hubMode = queryParams.get(HUB_MODE);
                 string[] hubTopic = queryParams.get(HUB_TOPIC);
                 params[HUB_MODE] = hubMode.length() == 1 ? hubMode[0] : "";
@@ -100,7 +100,8 @@ service class HttpService {
             _ => {
                 response.statusCode = http:STATUS_BAD_REQUEST;
                 string errorMessage = "Endpoint only supports content type of application/x-www-form-urlencoded, " +
-                                        "application/json, application/xml, application/octet-stream and text/plain";
+                                        "application/json, application/xml, application/octet-stream, text/plain, " +
+                                        "multipart/form-data, multipart/mixed and multipart/alternative";
                 response.setTextPayload(errorMessage);
                 respondToRequest(caller, response);
             }
@@ -173,6 +174,13 @@ service class HttpService {
                         msgType: PUBLISH,
                         contentType: contentType,
                         content: check request.getTextPayload()
+                    };
+                } else if (contentType == mime:MULTIPART_FORM_DATA || contentType == mime:MULTIPART_MIXED || contentType == mime:MULTIPART_ALTERNATIVE) {
+                    updateMsg = {
+                        hubTopic: <string> topic,
+                        msgType: PUBLISH,
+                        contentType: contentType, 
+                        content: check request.getBodyParts()
                     };
                 } else {
                     updateMsg = {

--- a/websubhub-ballerina/publisher_client.bal
+++ b/websubhub-ballerina/publisher_client.bal
@@ -118,7 +118,7 @@ public client class PublisherClient {
     # + payload - The update payload
     # + contentType - The type of the update content to set as the `ContentType` header
     # + return -  An `error`if an error occurred with the update or else `()`
-    isolated remote function publishUpdate(string topic, map<string>|string|xml|json|byte[] payload,
+    isolated remote function publishUpdate(string topic, map<string>|string|xml|json|byte[]|mime:Entity[] payload,
                                   string? contentType = ()) returns @tainted Acknowledgement|UpdateMessageError {
         http:Client httpClient = self.httpClient;
         http:Request request = new;

--- a/websubhub-ballerina/tests/ssl_enabled_hub_test.bal
+++ b/websubhub-ballerina/tests/ssl_enabled_hub_test.bal
@@ -15,6 +15,7 @@
 // under the License.
 
 import ballerina/http;
+import ballerina/io;
 import ballerina/log;
 import ballerina/test;
 
@@ -45,7 +46,7 @@ service /websubhub on hubListener {
 
     isolated remote function onUpdateMessage(UpdateMessage message)
                returns Acknowledgement|UpdateMessageError {
-        log:printDebug("Received content-update request ", message = message);
+        io:println("Received content-update request ", message);       
         return ACKNOWLEDGEMENT;
     }
     

--- a/websubhub-ballerina/tests/utils_test.bal
+++ b/websubhub-ballerina/tests/utils_test.bal
@@ -71,6 +71,23 @@ isolated function testContentTypeRetrievalForByteArray() returns @tainted error?
     test:assertEquals(contentType, mime:APPLICATION_OCTET_STREAM);
 }
 
+@test:Config { 
+    groups: ["contentTypeRetrieval"]
+}
+function testContentTypeRetrievalForMime() returns @tainted error? {
+    mime:Entity jsonBodyPart = new;
+    jsonBodyPart.setContentDisposition(getContentDispositionForFormData("json part"));
+    jsonBodyPart.setJson({"name": "Ballerina"});
+
+    mime:Entity textBodyPart = new;
+    textBodyPart.setContentDisposition(getContentDispositionForFormData("text part"));
+    textBodyPart.setText("Sample text");
+
+    mime:Entity[] content = [jsonBodyPart, textBodyPart];
+    string contentType = retrieveContentType((), content);
+    test:assertEquals(contentType, mime:MULTIPART_FORM_DATA);
+}
+
 const string HASH_KEY = "secret";
 
 @test:Config { 
@@ -127,6 +144,22 @@ isolated function testByteArrayContentSignature() returns @tainted error? {
     test:assertEquals("d66181d67f963fff2dde0b0a4ca50ac1a6bc5828dd32eabaf0d5049f6fe8b5ff", hashedContent.toBase16());
 }
 
+@test:Config { 
+    groups: ["contentSignature"]
+}
+function testMimeContentSignature() returns @tainted error? {
+    mime:Entity jsonBodyPart = new;
+    jsonBodyPart.setContentDisposition(getContentDispositionForFormData("json part"));
+    jsonBodyPart.setJson({"name": "Ballerina"});
+
+    mime:Entity textBodyPart = new;
+    textBodyPart.setContentDisposition(getContentDispositionForFormData("text part"));
+    textBodyPart.setText("Sample text");
+
+    mime:Entity[] content = [jsonBodyPart, textBodyPart];
+    byte[] hashedContent = check retrievePayloadSignature(HASH_KEY, content);
+    test:assertEquals("fe3e32734ab4410af9e084b9153166b6ada5fba10200449d8aedac939605aec9", hashedContent.toBase16());
+}
 
 http:Client headerRetrievalTestingClient = checkpanic new ("http://localhost:9191/subscriber");
 


### PR DESCRIPTION
## Purpose
Support mime content delivery for websubhub


## Samples
```
public type ContentDistributionMessage record {|
    map<string|string[]>? headers = ();
    string? contentType = ();
    map<string>|json|xml|string|byte[]|mime:Entity[] content;
|};
```
```
public type UpdateMessage record {
    MessageType msgType;
    string hubTopic;
    string contentType;
    string|byte[]|json|xml|map<string>?|mime:Entity[] content;
};
```
