### PR TITLE
Refactor websubhub sample

### DIFF
--- a/websubhub-examples/kafka-hub/hub/hub_service.bal
+++ b/websubhub-examples/kafka-hub/hub/hub_service.bal
@@ -190,7 +190,6 @@ websubhub:Service hubService = service object {
                 log:printError("Error occurred while persisting the subscription ", err = persistingResult.message());
             }
         }
-        error? notificationError = notifySubscriber(hubClientEp, consumerEp, groupName);
     }
 
     # Unsubscribes a consumer from the hub.

--- a/websubhub-examples/kafka-hub/hub/modules/connections/connections.bal
+++ b/websubhub-examples/kafka-hub/hub/modules/connections/connections.bal
@@ -24,6 +24,7 @@ kafka:ProducerConfiguration producerConfig = {
     acks: "1",
     retryCount: 3
 };
+// Producer which publishes the content-updates to Kafka 
 public final kafka:Producer updateMessageProducer = check new (config:KAFKA_BOOTSTRAP_NODE, producerConfig);
 
 kafka:ProducerConfiguration statePersistConfig = {
@@ -31,6 +32,7 @@ kafka:ProducerConfiguration statePersistConfig = {
     acks: "1",
     retryCount: 3
 };
+// Producer which persist the current in-memory state of the Hub 
 public final kafka:Producer statePersistProducer = check new (config:KAFKA_BOOTSTRAP_NODE, statePersistConfig);
 
 kafka:ConsumerConfiguration subscribersConsumerConfig = {
@@ -38,6 +40,7 @@ kafka:ConsumerConfiguration subscribersConsumerConfig = {
     offsetReset: "earliest",
     topics: [ config:SUBSCRIBERS_TOPIC ]
 };
+// Consumer which reads the persisted subscriber details
 public final kafka:Consumer subscribersConsumer = check new (config:KAFKA_BOOTSTRAP_NODE, subscribersConsumerConfig);
 
 kafka:ConsumerConfiguration registeredTopicsConsumerConfig = {
@@ -45,8 +48,13 @@ kafka:ConsumerConfiguration registeredTopicsConsumerConfig = {
     offsetReset: "earliest",
     topics: [ config:REGISTERED_TOPICS_TOPIC ]
 };
+// Consumer which reads the persisted subscriber details
 public final kafka:Consumer registeredTopicsConsumer = check new (config:KAFKA_BOOTSTRAP_NODE, registeredTopicsConsumerConfig);
 
+# Creates a `kafka:Consumer` for a subscriber.
+# 
+# + message - The subscription details
+# + return - `kafka:Consumer` if succcessful or else `error`
 public isolated function createMessageConsumer(websubhub:VerifiedSubscription message) returns kafka:Consumer|error {
     string topicName = util:sanitizeTopicName(message.hubTopic);
     string groupName = util:generateGroupName(message.hubTopic, message.hubCallback);

--- a/websubhub-examples/kafka-hub/hub/modules/security/security.bal
+++ b/websubhub-examples/kafka-hub/hub/modules/security/security.bal
@@ -37,6 +37,11 @@ final http:ListenerJwtAuthHandler handler = new({
     scopeKey: "scope"
 });
 
+# Checks for authorization for the current request.
+# 
+# + headers - `http:Headers` for the current request
+# + authScopes - Requested auth-scopes to access the current resource
+# + return - `error` if there is any authorization error or else `()`
 public isolated function authorize(http:Headers headers, string[] authScopes) returns error? {
     string|http:HeaderNotFoundError authHeader = headers.getHeader(http:AUTH_HEADER);
     if (authHeader is string) {

--- a/websubhub-examples/kafka-hub/hub/modules/util/util.bal
+++ b/websubhub-examples/kafka-hub/hub/modules/util/util.bal
@@ -18,19 +18,35 @@ import ballerina/regex;
 import ballerina/random;
 import ballerina/lang.'string as strings;
 
+# Sanitizes the name of the `topic` by replacing special characters with `_`.
+# 
+# + topic - Name of the `topic`
+# + return - Sanitized topic name
 public isolated function sanitizeTopicName(string topic) returns string {
     return nomalizeString(topic);
 }
 
+# Generates a group-name for a subscriber.
+# 
+# + topic - The `topic` which subscriber needs to subscribe
+# + callbackUrl - Subscriber callback URL
+# + return - Generated group-name for subscriber
 public isolated function generateGroupName(string topic, string callbackUrl) returns string {
     string idValue = topic + ":::" + callbackUrl;
     return nomalizeString(idValue);
 }
 
+# Normalizes a `string` by replacing special characters with `_`.
+# 
+# + baseString - `string` to be normalized
+# + return - Normalized `string`
 isolated function nomalizeString(string baseString) returns string {
     return regex:replaceAll(baseString, "[^a-zA-Z0-9]", "_");
 }
 
+# Generates a random `string` of 10 characters
+# 
+# + return - The generated `string`
 public isolated function generateRandomString() returns string {
     int[] codePoints = [];
     int leftLimit = 48; // numeral '0'


### PR DESCRIPTION
## Purpose
> $subject

* Add doc-comments for connections / security / util modules.
* Fix logic issue in invoking content-notification async function.
  * Here notifySubscriber async function should only be invoked when there is a new subscription. And when the Hub is restarted it should start notifySubscriber for all the persisted subscribers as well.
  * When an unsubscription happens we could check whether it is available in registeredSubscribers state and cancel the previously invoked async function.

## Checklist
~~Linked to an issue~~ N/A
~~Updated the changelog~~ N/A
~~Added tests~~ N/A
