### PR TITLE
Mark WebSubHub service-type distinct

### DIFF
--- a/ballerina/http_service.bal
+++ b/ballerina/http_service.bal
@@ -18,6 +18,8 @@ import ballerina/http;
 import ballerina/mime;
 
 isolated service class HttpService {
+    *http:Service;
+    
     private final HttpToWebsubhubAdaptor adaptor;
     private final readonly & ClientConfiguration clientConfig;
     private final string hub;

--- a/ballerina/hub_service.bal
+++ b/ballerina/hub_service.bal
@@ -14,7 +14,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-public type Service service object {
+public type Service distinct service object {
 
    //todo Remove methods and write compiler plugin for service
 

--- a/ballerina/tests/additional_error_details_test.bal
+++ b/ballerina/tests/additional_error_details_test.bal
@@ -21,7 +21,7 @@ import ballerina/regex;
 
 listener Listener hubListenerToAdditionalErrorDetails = new(9093);
 
-var hubServiceToTestAdditionalErrorDetails = service object {
+Service hubServiceToTestAdditionalErrorDetails = service object {
 
     isolated remote function onRegisterTopic(TopicRegistration message)
                                 returns TopicRegistrationError {

--- a/ballerina/tests/hub_with_header_details_test.bal
+++ b/ballerina/tests/hub_with_header_details_test.bal
@@ -20,7 +20,7 @@ import ballerina/test;
 
 listener Listener hubWithHeaderDetailsListener = new(9095);
 
-var hubWithHeaderDetails = service object {
+Service hubWithHeaderDetails = service object {
 
     isolated remote function onRegisterTopic(TopicRegistration message, http:Headers headers)
                                 returns TopicRegistrationSuccess {

--- a/ballerina/tests/test_init.bal
+++ b/ballerina/tests/test_init.bal
@@ -26,7 +26,7 @@ map<string|string[]> CUSTOM_HEADERS = {
         "header3": ["value4"]
 };
 
-var simpleSubscriber = service object {
+http:Service simpleSubscriber = service object {
 
     isolated resource function get .(http:Caller caller, http:Request req)
             returns error? {

--- a/changelog.md
+++ b/changelog.md
@@ -6,6 +6,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+- [Mark WebSubHub Service type as distinct](https://github.com/ballerina-platform/ballerina-standard-library/issues/2398)
+
+## [2.0.0] - 2021-10-09
+
 ### Added
 - [Add `hubMode` field to topic-registration and topic-deregistration request body](https://github.com/ballerina-platform/ballerina-standard-library/issues/1638)
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,7 +1,7 @@
 org.gradle.caching=true
 group=io.ballerina.stdlib
 version=1.0.1-SNAPSHOT
-ballerinaLangVersion=2.0.0-beta.4-20211112-202600-603eab0f
+ballerinaLangVersion=2.0.0-beta.4-20211117-131600-4133d87c
 
 puppycrawlCheckstyleVersion=8.18
 testngVersion=7.4.0


### PR DESCRIPTION
## Purpose
> $subject

Related to [#2398](https://github.com/ballerina-platform/ballerina-standard-library/issues/2398)

## Examples
### 1. Service Declaration
```ballerina
listener websubhub:Listener ls = new (9090);

service /hub on ls {
   // implement remote methods
}
```
### 2. Service Object
```ballerina
listener websubhub:Listener ls = new (9090);

websubhub:Service hubService = service object {
    // implement remote methods
};

ls.attach(hubService, "hub");
```
### 3. Service Class
```ballerina
service class HubService {
    *websubhub:Service;

   // implement remote methods
}

HubService hubService = new ();
ls.attach(hubService, "sub");
```
 
## Checklist
- [X] Linked to an issue
- [x] Updated the changelog
- [ ] Added tests
