### PR TITLE
`readonly` support for the parameters of remote methods

### DIFF
--- a/ballerina/tests/hub_with_readonly_params_test.bal
+++ b/ballerina/tests/hub_with_readonly_params_test.bal
@@ -1,0 +1,117 @@
+// Copyright (c) 2022 WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+//
+// WSO2 Inc. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import ballerina/http;
+import ballerina/io;
+import ballerina/mime;
+import ballerina/test;
+
+service /websubhub on new Listener(9102) {
+    isolated remote function onRegisterTopic(readonly & TopicRegistration msg) returns TopicRegistrationSuccess {
+        test:assertTrue(msg is readonly);
+        return TOPIC_REGISTRATION_SUCCESS;
+    }
+
+    isolated remote function onDeregisterTopic(readonly & TopicDeregistration msg) returns TopicDeregistrationSuccess {
+        test:assertTrue(msg is readonly);
+        return TOPIC_DEREGISTRATION_SUCCESS;
+    }
+
+    isolated remote function onUpdateMessage(readonly & UpdateMessage msg) returns Acknowledgement {
+        test:assertTrue(msg is readonly);
+        return ACKNOWLEDGEMENT;
+    }
+
+    isolated function onSubscription(readonly & Subscription msg) returns SubscriptionAccepted {
+        test:assertTrue(msg is readonly);
+        return SUBSCRIPTION_ACCEPTED;
+    }
+
+    remote function onSubscriptionValidation(readonly & Subscription msg) {
+        test:assertTrue(msg is readonly);
+    }
+    
+    isolated remote function onSubscriptionIntentVerified(readonly & VerifiedSubscription msg) {
+        test:assertTrue(msg is readonly);
+    }
+
+    isolated function onUnsubscription(readonly & Subscription msg) returns SubscriptionAccepted {
+        return UNSUBSCRIPTION_ACCEPTED;
+    }
+
+    remote function onUnsubscriptionValidation(readonly & Unsubscription msg) {
+        test:assertTrue(msg is readonly);
+    }
+
+    isolated remote function onUnsubscriptionIntentVerified(readonly & VerifiedUnsubscription msg){
+        test:assertTrue(msg is readonly);
+    }
+}
+
+PublisherClient readonlyParamsTestPublisher = check new ("http://localhost:9102/websubhub");
+
+@test:Config{}
+public function testPublisherRegisterSuccessWithReadonly() returns error? {
+    TopicRegistrationSuccess registrationResponse = check readonlyParamsTestPublisher->registerTopic("test");
+    io:println(registrationResponse);
+}
+
+@test:Config{}
+public function testPublisherDeregisterSuccessWithReadonly() returns error? {
+    TopicDeregistrationSuccess deRegistrationResponse = check readonlyParamsTestPublisher->deregisterTopic("test");
+    io:println(deRegistrationResponse);
+}
+
+@test:Config{}
+public function testPublisherNotifyEvenSuccessWithReadonly() returns error? {
+    Acknowledgement response = check readonlyParamsTestPublisher->notifyUpdate("test");
+    io:println(response);
+}
+
+@test:Config {}
+public function testPublisherPubishEventSuccessWithReadonly() returns error? {
+    map<string> params = {event: "event"};
+    Acknowledgement response = check readonlyParamsTestPublisher->publishUpdate("test", params);
+    io:println(response);
+}
+
+http:Client readonlyParamsTestSubscriber = check new ("http://localhost:9102/websubhub");
+
+@test:Config {
+    groups: [
+        "readOnlyParams"
+    ]
+}
+public function testSubscriptionSuccessWithReadonly() returns error? {
+    http:Request req = new;
+    string payload = string `${HUB_MODE}=unsubscribe&${HUB_TOPIC}=test&${HUB_CALLBACK}=http://localhost:9191/subscriber`;
+    req.setTextPayload(payload, mime:APPLICATION_FORM_URLENCODED);
+    http:Response response = check readonlyParamsTestSubscriber->post("", req);
+    test:assertEquals(response.statusCode, 202, "Unexpected response status-code");
+}
+
+@test:Config {
+    groups: [
+        "readOnlyParams"
+    ]
+}
+public function testUnsubscriptionSuccessWithReadonly() returns error? {
+    http:Request req = new;
+    string payload = string `${HUB_MODE}=unsubscribe&${HUB_TOPIC}=test&${HUB_CALLBACK}=http://localhost:9191/subscriber`;
+    req.setTextPayload(payload, mime:APPLICATION_FORM_URLENCODED);
+    http:Response response = check readonlyParamsTestSubscriber->post("", req);
+    test:assertEquals(response.statusCode, 202, "Unexpected response status-code");
+}

--- a/ballerina/tests/hub_with_readonly_params_test.bal
+++ b/ballerina/tests/hub_with_readonly_params_test.bal
@@ -49,6 +49,7 @@ service /websubhub on new Listener(9102) {
     }
 
     isolated function onUnsubscription(readonly & Subscription msg) returns SubscriptionAccepted {
+        test:assertTrue(msg is readonly);
         return UNSUBSCRIPTION_ACCEPTED;
     }
 

--- a/ballerina/tests/hub_with_readonly_params_test.bal
+++ b/ballerina/tests/hub_with_readonly_params_test.bal
@@ -97,7 +97,7 @@ http:Client readonlyParamsTestSubscriber = check new ("http://localhost:9102/web
 }
 public function testSubscriptionSuccessWithReadonly() returns error? {
     http:Request req = new;
-    string payload = string `${HUB_MODE}=unsubscribe&${HUB_TOPIC}=test&${HUB_CALLBACK}=http://localhost:9191/subscriber`;
+    string payload = string `${HUB_MODE}=subscribe&${HUB_TOPIC}=test&${HUB_CALLBACK}=http://localhost:9191/subscriber`;
     req.setTextPayload(payload, mime:APPLICATION_FORM_URLENCODED);
     http:Response response = check readonlyParamsTestSubscriber->post("", req);
     test:assertEquals(response.statusCode, 202, "Unexpected response status-code");

--- a/changelog.md
+++ b/changelog.md
@@ -6,10 +6,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- [WebSub/WebSubHub should support `readonly` parameters for remote methods](https://github.com/ballerina-platform/ballerina-standard-library/issues/2604)
+
+## [1.0.1] - 2021-12-14
+
 ### Changed
 - [Mark WebSubHub Service type as distinct](https://github.com/ballerina-platform/ballerina-standard-library/issues/2398)
 
-## [2.0.0] - 2021-10-09
+## [1.0.0] - 2021-10-09
 
 ### Added
 - [Add `hubMode` field to topic-registration and topic-deregistration request body](https://github.com/ballerina-platform/ballerina-standard-library/issues/1638)

--- a/compiler-plugin-tests/src/test/resources/ballerina_sources/sample_19/Ballerina.toml
+++ b/compiler-plugin-tests/src/test/resources/ballerina_sources/sample_19/Ballerina.toml
@@ -1,0 +1,7 @@
+[package]
+org = "websubhub_test"
+name = "sample_19"
+version = "0.1.0"
+
+[build-options]
+observabilityIncluded = true

--- a/compiler-plugin-tests/src/test/resources/ballerina_sources/sample_19/service.bal
+++ b/compiler-plugin-tests/src/test/resources/ballerina_sources/sample_19/service.bal
@@ -1,0 +1,118 @@
+// Copyright (c) 2022 WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+//
+// WSO2 Inc. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import ballerina/websubhub;
+import ballerina/io;
+
+listener websubhub:Listener functionWithArgumentsListener = new(9090);
+
+service /websubhub on functionWithArgumentsListener {
+
+    isolated remote function onRegisterTopic(readonly & websubhub:TopicRegistration message)
+                                returns websubhub:TopicRegistrationSuccess|websubhub:TopicRegistrationError {
+        if (message.topic == "test") {
+            websubhub:TopicRegistrationSuccess successResult = {
+                body: <map<string>>{
+                       isSuccess: "true"
+                    }
+            };
+            return successResult;
+        } else {
+            return error websubhub:TopicRegistrationError("Registration Failed!");
+        }
+    }
+
+    isolated remote function onDeregisterTopic(readonly & websubhub:TopicDeregistration message)
+                        returns websubhub:TopicDeregistrationSuccess|websubhub:TopicDeregistrationError {
+
+        map<string> body = { isDeregisterSuccess: "true" };
+        websubhub:TopicDeregistrationSuccess deregisterResult = {
+            body
+        };
+        if (message.topic == "test") {
+            return deregisterResult;
+       } else {
+            return error websubhub:TopicDeregistrationError("Topic Deregistration Failed!");
+        }
+    }
+
+    isolated remote function onUpdateMessage(readonly & websubhub:UpdateMessage msg)
+               returns websubhub:Acknowledgement|websubhub:UpdateMessageError {
+        websubhub:Acknowledgement ack = {};
+        if (msg.hubTopic == "test") {
+            return ack;
+        } else if (!(msg.content is ())) {
+            return ack;
+        } else {
+            return error websubhub:UpdateMessageError("Error in accessing content");
+        }
+    }
+    
+    isolated remote function onSubscription(readonly & websubhub:Subscription msg)
+                returns websubhub:SubscriptionAccepted|websubhub:SubscriptionPermanentRedirect|websubhub:SubscriptionTemporaryRedirect
+                |websubhub:BadSubscriptionError|websubhub:InternalSubscriptionError {
+        websubhub:SubscriptionAccepted successResult = {
+                body: <map<string>>{
+                       isSuccess: "true"
+                    }
+            };
+        if (msg.hubTopic == "test") {
+            return successResult;
+        } else if (msg.hubTopic == "test1") {
+            return successResult;
+        } else {
+            return error websubhub:BadSubscriptionError("Bad subscription");
+        }
+    }
+
+    isolated remote function onSubscriptionValidation(readonly & websubhub:Subscription msg)
+                returns websubhub:SubscriptionDeniedError? {
+        if (msg.hubTopic == "test1") {
+            return error websubhub:SubscriptionDeniedError("Denied subscription for topic 'test1'");
+        }
+        return ();
+    }
+
+    isolated remote function onSubscriptionIntentVerified(readonly & websubhub:VerifiedSubscription msg) {
+        io:println("Subscription Intent verified invoked!");
+    }
+
+    isolated remote function onUnsubscription(readonly & websubhub:Unsubscription msg)
+               returns websubhub:UnsubscriptionAccepted|websubhub:BadUnsubscriptionError|websubhub:InternalUnsubscriptionError {
+        if (msg.hubTopic == "test" || msg.hubTopic == "test1" ) {
+            websubhub:UnsubscriptionAccepted successResult = {
+                body: <map<string>>{
+                       isSuccess: "true"
+                    }
+            };
+            return successResult;
+        } else {
+            return error websubhub:BadUnsubscriptionError("Denied unsubscription for topic '" + <string> msg.hubTopic + "'");
+        }
+    }
+
+    isolated remote function onUnsubscriptionValidation(readonly & websubhub:Unsubscription msg)
+                returns websubhub:UnsubscriptionDeniedError? {
+        if (msg.hubTopic == "test1") {
+            return error websubhub:UnsubscriptionDeniedError("Denied subscription for topic 'test1'");
+        }
+        return ();
+    }
+
+    isolated remote function onUnsubscriptionIntentVerified(readonly & websubhub:VerifiedUnsubscription msg){
+        io:println("Unsubscription Intent verified invoked!");
+    }
+}

--- a/compiler-plugin-tests/src/test/resources/ballerina_sources/sample_20/Ballerina.toml
+++ b/compiler-plugin-tests/src/test/resources/ballerina_sources/sample_20/Ballerina.toml
@@ -1,0 +1,7 @@
+[package]
+org = "websubhub_test"
+name = "sample_20"
+version = "0.1.0"
+
+[build-options]
+observabilityIncluded = true

--- a/compiler-plugin-tests/src/test/resources/ballerina_sources/sample_20/service.bal
+++ b/compiler-plugin-tests/src/test/resources/ballerina_sources/sample_20/service.bal
@@ -1,0 +1,119 @@
+// Copyright (c) 2022 WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+//
+// WSO2 Inc. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import ballerina/websubhub;
+import ballerina/http;
+import ballerina/io;
+
+listener websubhub:Listener functionWithArgumentsListener = new(9090);
+
+service /websubhub on functionWithArgumentsListener {
+
+    isolated remote function onRegisterTopic(readonly & websubhub:TopicRegistration message, readonly & http:Headers headers)
+                                returns websubhub:TopicRegistrationSuccess|websubhub:TopicRegistrationError {
+        if (message.topic == "test") {
+            websubhub:TopicRegistrationSuccess successResult = {
+                body: <map<string>>{
+                       isSuccess: "true"
+                    }
+            };
+            return successResult;
+        } else {
+            return error websubhub:TopicRegistrationError("Registration Failed!");
+        }
+    }
+
+    isolated remote function onDeregisterTopic(readonly & websubhub:TopicDeregistration message, readonly & http:Headers headers)
+                        returns websubhub:TopicDeregistrationSuccess|websubhub:TopicDeregistrationError {
+
+        map<string> body = { isDeregisterSuccess: "true" };
+        websubhub:TopicDeregistrationSuccess deregisterResult = {
+            body
+        };
+        if (message.topic == "test") {
+            return deregisterResult;
+       } else {
+            return error websubhub:TopicDeregistrationError("Topic Deregistration Failed!");
+        }
+    }
+
+    isolated remote function onUpdateMessage(readonly & websubhub:UpdateMessage msg, readonly & http:Headers headers)
+               returns websubhub:Acknowledgement|websubhub:UpdateMessageError {
+        websubhub:Acknowledgement ack = {};
+        if (msg.hubTopic == "test") {
+            return ack;
+        } else if (!(msg.content is ())) {
+            return ack;
+        } else {
+            return error websubhub:UpdateMessageError("Error in accessing content");
+        }
+    }
+    
+    isolated remote function onSubscription(readonly & websubhub:Subscription msg, readonly & http:Headers headers)
+                returns websubhub:SubscriptionAccepted|websubhub:SubscriptionPermanentRedirect|websubhub:SubscriptionTemporaryRedirect
+                |websubhub:BadSubscriptionError|websubhub:InternalSubscriptionError {
+        websubhub:SubscriptionAccepted successResult = {
+                body: <map<string>>{
+                       isSuccess: "true"
+                    }
+            };
+        if (msg.hubTopic == "test") {
+            return successResult;
+        } else if (msg.hubTopic == "test1") {
+            return successResult;
+        } else {
+            return error websubhub:BadSubscriptionError("Bad subscription");
+        }
+    }
+
+    isolated remote function onSubscriptionValidation(readonly & websubhub:Subscription msg)
+                returns websubhub:SubscriptionDeniedError? {
+        if (msg.hubTopic == "test1") {
+            return error websubhub:SubscriptionDeniedError("Denied subscription for topic 'test1'");
+        }
+        return ();
+    }
+
+    isolated remote function onSubscriptionIntentVerified(readonly & websubhub:VerifiedSubscription msg) {
+        io:println("Subscription Intent verified invoked!");
+    }
+
+    isolated remote function onUnsubscription(readonly & websubhub:Unsubscription msg, readonly & http:Headers headers)
+               returns websubhub:UnsubscriptionAccepted|websubhub:BadUnsubscriptionError|websubhub:InternalUnsubscriptionError {
+        if (msg.hubTopic == "test" || msg.hubTopic == "test1" ) {
+            websubhub:UnsubscriptionAccepted successResult = {
+                body: <map<string>>{
+                       isSuccess: "true"
+                    }
+            };
+            return successResult;
+        } else {
+            return error websubhub:BadUnsubscriptionError("Denied unsubscription for topic '" + <string> msg.hubTopic + "'");
+        }
+    }
+
+    isolated remote function onUnsubscriptionValidation(readonly & websubhub:Unsubscription msg)
+                returns websubhub:UnsubscriptionDeniedError? {
+        if (msg.hubTopic == "test1") {
+            return error websubhub:UnsubscriptionDeniedError("Denied subscription for topic 'test1'");
+        }
+        return ();
+    }
+
+    isolated remote function onUnsubscriptionIntentVerified(readonly & websubhub:VerifiedUnsubscription msg){
+        io:println("Unsubscription Intent verified invoked!");
+    }
+}

--- a/compiler-plugin/src/main/java/io/ballerina/stdlib/websubhub/Constants.java
+++ b/compiler-plugin/src/main/java/io/ballerina/stdlib/websubhub/Constants.java
@@ -62,6 +62,7 @@ public interface Constants {
     String UNSUBSCRIPTION_DENIED_ERROR = "websubhub:UnsubscriptionDeniedError";
     String ACKNOWLEDGEMENT = "websubhub:Acknowledgement";
     String ERROR = "annotations:error";
+    String READONLY = "readonly";
 
     String OPTIONAL = "?";
 }

--- a/native/src/main/java/io/ballerina/stdlib/websubhub/Constants.java
+++ b/native/src/main/java/io/ballerina/stdlib/websubhub/Constants.java
@@ -26,4 +26,14 @@ public interface Constants {
     String PACKAGE_NAME = "websubhub";
 
     String SERVICE_OBJECT = "WEBSUBHUB_SERVICE_OBJECT";
+
+    String ON_REGISTER_TOPIC = "onRegisterTopic";
+    String ON_DEREGISTER_TOPIC = "onDeregisterTopic";
+    String ON_UPDATE_MESSAGE = "onUpdateMessage";
+    String ON_SUBSCRIPTION = "onSubscription";
+    String ON_SUBSCRIPTION_VALIDATION = "onSubscriptionValidation";
+    String ON_SUBSCRIPTION_INTENT_VERIFIED = "onSubscriptionIntentVerified";
+    String ON_UNSUBSCRIPTION = "onUnsubscription";
+    String ON_UNSUBSCRIPTION_VALIDATION = "onUnsubscriptionValidation";
+    String ON_UNSUBSCRIPTION_INTENT_VERIFIED = "onUnsubscriptionIntentVerified";
 }

--- a/native/src/main/java/io/ballerina/stdlib/websubhub/NativeHttpToWebsubhubAdaptor.java
+++ b/native/src/main/java/io/ballerina/stdlib/websubhub/NativeHttpToWebsubhubAdaptor.java
@@ -22,9 +22,13 @@ import io.ballerina.runtime.api.Environment;
 import io.ballerina.runtime.api.Future;
 import io.ballerina.runtime.api.Module;
 import io.ballerina.runtime.api.PredefinedTypes;
+import io.ballerina.runtime.api.TypeTags;
 import io.ballerina.runtime.api.async.StrandMetadata;
 import io.ballerina.runtime.api.creators.ValueCreator;
+import io.ballerina.runtime.api.types.IntersectionType;
 import io.ballerina.runtime.api.types.MethodType;
+import io.ballerina.runtime.api.types.Parameter;
+import io.ballerina.runtime.api.types.Type;
 import io.ballerina.runtime.api.utils.StringUtils;
 import io.ballerina.runtime.api.values.BArray;
 import io.ballerina.runtime.api.values.BMap;
@@ -32,7 +36,17 @@ import io.ballerina.runtime.api.values.BObject;
 import io.ballerina.runtime.api.values.BString;
 
 import java.util.ArrayList;
+import java.util.List;
 
+import static io.ballerina.stdlib.websubhub.Constants.ON_DEREGISTER_TOPIC;
+import static io.ballerina.stdlib.websubhub.Constants.ON_REGISTER_TOPIC;
+import static io.ballerina.stdlib.websubhub.Constants.ON_SUBSCRIPTION;
+import static io.ballerina.stdlib.websubhub.Constants.ON_SUBSCRIPTION_INTENT_VERIFIED;
+import static io.ballerina.stdlib.websubhub.Constants.ON_SUBSCRIPTION_VALIDATION;
+import static io.ballerina.stdlib.websubhub.Constants.ON_UNSUBSCRIPTION;
+import static io.ballerina.stdlib.websubhub.Constants.ON_UNSUBSCRIPTION_INTENT_VERIFIED;
+import static io.ballerina.stdlib.websubhub.Constants.ON_UNSUBSCRIPTION_VALIDATION;
+import static io.ballerina.stdlib.websubhub.Constants.ON_UPDATE_MESSAGE;
 import static io.ballerina.stdlib.websubhub.Constants.SERVICE_OBJECT;
 
 /**
@@ -45,7 +59,7 @@ public class NativeHttpToWebsubhubAdaptor {
 
     public static BArray getServiceMethodNames(BObject adaptor) {
         BObject bHubService = (BObject) adaptor.getNativeData(SERVICE_OBJECT);
-        ArrayList<BString> methodNamesList = new ArrayList<>();
+        List<BString> methodNamesList = new ArrayList<>();
         for (MethodType method : bHubService.getType().getMethods()) {
             methodNamesList.add(StringUtils.fromString(method.getName()));
         }
@@ -55,74 +69,127 @@ public class NativeHttpToWebsubhubAdaptor {
     public static Object callRegisterMethod(Environment env, BObject adaptor,
                                             BMap<BString, Object> message, BObject bHttpHeaders) {
         BObject bHubService = (BObject) adaptor.getNativeData(SERVICE_OBJECT);
+        boolean isReadOnly = isReadOnlyParam(bHubService, ON_REGISTER_TOPIC);
+        if (isReadOnly) {
+            message.freezeDirect();
+        }
         Object[] args = new Object[]{message, true, bHttpHeaders, true};
         return invokeRemoteFunction(env, bHubService, args,
-                "callRegisterMethod", "onRegisterTopic");
+                "callRegisterMethod", ON_REGISTER_TOPIC);
     }
 
     public static Object callDeregisterMethod(Environment env, BObject adaptor,
                                               BMap<BString, Object> message, BObject bHttpHeaders) {
         BObject bHubService = (BObject) adaptor.getNativeData(SERVICE_OBJECT);
+        boolean isReadOnly = isReadOnlyParam(bHubService, ON_DEREGISTER_TOPIC);
+        if (isReadOnly) {
+            message.freezeDirect();
+        }
         Object[] args = new Object[]{message, true, bHttpHeaders, true};
         return invokeRemoteFunction(env, bHubService, args,
-                "callDeregisterMethod", "onDeregisterTopic");
+                "callDeregisterMethod", ON_DEREGISTER_TOPIC);
     }
 
     public static Object callOnUpdateMethod(Environment env, BObject adaptor,
                                             BMap<BString, Object> message, BObject bHttpHeaders) {
         BObject bHubService = (BObject) adaptor.getNativeData(SERVICE_OBJECT);
+        boolean isReadOnly = isReadOnlyParam(bHubService, ON_UPDATE_MESSAGE);
+        if (isReadOnly) {
+            message.freezeDirect();
+        }
         Object[] args = new Object[]{message, true, bHttpHeaders, true};
         return invokeRemoteFunction(env, bHubService, args,
-                "callOnUpdateMethod", "onUpdateMessage");
+                "callOnUpdateMethod", ON_UPDATE_MESSAGE);
     }
 
     public static Object callOnSubscriptionMethod(Environment env, BObject adaptor,
                                                   BMap<BString, Object> message, BObject bHttpHeaders) {
         BObject bHubService = (BObject) adaptor.getNativeData(SERVICE_OBJECT);
+        boolean isReadOnly = isReadOnlyParam(bHubService, ON_SUBSCRIPTION);
+        if (isReadOnly) {
+            message.freezeDirect();
+        }
         Object[] args = new Object[]{message, true, bHttpHeaders, true};
         return invokeRemoteFunction(env, bHubService, args,
-                "callOnSubscriptionMethod", "onSubscription");
+                "callOnSubscriptionMethod", ON_SUBSCRIPTION);
     }
 
     public static Object callOnSubscriptionValidationMethod(Environment env, BObject adaptor,
                                                             BMap<BString, Object> message, BObject bHttpHeaders) {
         BObject bHubService = (BObject) adaptor.getNativeData(SERVICE_OBJECT);
+        boolean isReadOnly = isReadOnlyParam(bHubService, ON_SUBSCRIPTION_VALIDATION);
+        if (isReadOnly) {
+            message.freezeDirect();
+        }
         Object[] args = new Object[]{message, true, bHttpHeaders, true};
         return invokeRemoteFunction(env, bHubService, args,
-                "callOnSubscriptionValidationMethod", "onSubscriptionValidation");
+                "callOnSubscriptionValidationMethod", ON_SUBSCRIPTION_VALIDATION);
     }
 
     public static Object callOnSubscriptionIntentVerifiedMethod(Environment env, BObject adaptor,
                                                                 BMap<BString, Object> message, BObject bHttpHeaders) {
         BObject bHubService = (BObject) adaptor.getNativeData(SERVICE_OBJECT);
+        boolean isReadOnly = isReadOnlyParam(bHubService, ON_SUBSCRIPTION_INTENT_VERIFIED);
+        if (isReadOnly) {
+            message.freezeDirect();
+        }
         Object[] args = new Object[]{message, true, bHttpHeaders, true};
         return invokeRemoteFunction(env, bHubService, args,
                 "callOnSubscriptionIntentVerifiedMethod",
-                "onSubscriptionIntentVerified");
+                ON_SUBSCRIPTION_INTENT_VERIFIED);
     }
 
     public static Object callOnUnsubscriptionMethod(Environment env, BObject adaptor,
                                                     BMap<BString, Object> message, BObject bHttpHeaders) {
         BObject bHubService = (BObject) adaptor.getNativeData(SERVICE_OBJECT);
+        boolean isReadOnly = isReadOnlyParam(bHubService, ON_UNSUBSCRIPTION);
+        if (isReadOnly) {
+            message.freezeDirect();
+        }
         Object[] args = new Object[]{message, true, bHttpHeaders, true};
         return invokeRemoteFunction(env, bHubService, args,
-                "callOnUnsubscriptionMethod", "onUnsubscription");
+                "callOnUnsubscriptionMethod", ON_UNSUBSCRIPTION);
     }
 
     public static Object callOnUnsubscriptionValidationMethod(Environment env, BObject adaptor,
                                                               BMap<BString, Object> message, BObject bHttpHeaders) {
         BObject bHubService = (BObject) adaptor.getNativeData(SERVICE_OBJECT);
+        boolean isReadOnly = isReadOnlyParam(bHubService, ON_UNSUBSCRIPTION_VALIDATION);
+        if (isReadOnly) {
+            message.freezeDirect();
+        }
         Object[] args = new Object[]{message, true, bHttpHeaders, true};
         return invokeRemoteFunction(env, bHubService, args, "callOnUnsubscriptionValidationMethod",
-                "onUnsubscriptionValidation");
+                ON_UNSUBSCRIPTION_VALIDATION);
     }
 
     public static Object callOnUnsubscriptionIntentVerifiedMethod(Environment env, BObject adaptor,
                                                                   BMap<BString, Object> message, BObject bHttpHeaders) {
         BObject bHubService = (BObject) adaptor.getNativeData(SERVICE_OBJECT);
+        boolean isReadOnly = isReadOnlyParam(bHubService, ON_UNSUBSCRIPTION_INTENT_VERIFIED);
+        if (isReadOnly) {
+            message.freezeDirect();
+        }
         Object[] args = new Object[]{message, true, bHttpHeaders, true};
         return invokeRemoteFunction(env, bHubService, args, "callOnUnsubscriptionIntentVerifiedMethod",
-                "onUnsubscriptionIntentVerified");
+                ON_UNSUBSCRIPTION_INTENT_VERIFIED);
+    }
+
+    private static boolean isReadOnlyParam(BObject serviceObj, String remoteMethod) {
+        for (MethodType method : serviceObj.getType().getMethods()) {
+            if (method.getName().equals(remoteMethod)) {
+                Parameter[] parameters = method.getParameters();
+                if (parameters.length >= 1) {
+                    Parameter parameter = parameters[0];
+                    Type paramType = parameter.type;
+                    if (paramType instanceof IntersectionType) {
+                        List<Type> constituentTypes = ((IntersectionType) paramType).getConstituentTypes();
+                        return constituentTypes.stream().anyMatch(t -> TypeTags.READONLY_TAG == t.getTag());
+                    }
+                }
+            }
+        }
+        return false;
     }
 
     private static Object invokeRemoteFunction(Environment env, BObject bHubService, Object[] args,


### PR DESCRIPTION
## Purpose
> $subject

Related to [#2604](https://github.com/ballerina-platform/ballerina-standard-library/issues/2604)

## Examples
With this change, developers could use `readonly` parameters for remote methods in `websubhub:Service` declaration:
```ballerina
service /websubhub on hubListener {
    isolated remote function onRegisterTopic(readonly & websubhub:TopicRegistration msg) returns websubhub:TopicRegistrationSuccess|websubhub:TopicRegistrationError {
        // implement logic here
    }

    // implement other remote methods
}
```

`readonly` can only be applied to records declared in WebSubHub package. Hence, following will be invalid:
```ballerina
service /websubhub on hubListener {
    isolated remote function onRegisterTopic(readonly & websubhub:TopicRegistration msg, readonly & http:Headers headers) returns websubhub:TopicRegistrationSuccess|websubhub:TopicRegistrationError {
        // implement logic here
    }

    // implement other remote methods
}
```

## Checklist
- [X] Linked to an issue
- [X] Updated the changelog
- [X] Added tests
