### PR TITLE
Improve event processing logic for consolidator-service

### DIFF
--- a/examples/kafka-hub/consolidator/consolidator_service.bal
+++ b/examples/kafka-hub/consolidator/consolidator_service.bal
@@ -27,9 +27,8 @@ isolated function startConsolidator() returns error? {
     do {
         while true {
             kafka:ConsumerRecord[] records = check conn:websubEventConsumer->poll(config:POLLING_INTERVAL);
-            if records.length() > 0 {
-                kafka:ConsumerRecord lastRecord = records.pop();
-                string lastPersistedData = check string:fromBytes(lastRecord.value);
+            foreach kafka:ConsumerRecord currentRecord in records {
+                string lastPersistedData = check string:fromBytes(currentRecord.value);
                 error? result = processPersistedData(lastPersistedData);
                 if result is error {
                     log:printError("Error occurred while processing received event ", 'error = result);


### PR DESCRIPTION
## Purpose
> $subject

In kafka-hub sample, `consolidator-service` currently processes only the last event retrieved from the `poll`. But the consolidator should process all the events received from the `poll`. 

## Examples
N/A

## Checklist
- [ ] Linked to an issue
- [ ] Updated the changelog
- [ ] Added tests
- [ ] Updated the spec
