### PR TITLE
[FIX] Compiler plugin crashes when using a new-expr with a user-defined class in the same source

### DIFF
--- a/ballerina/Ballerina.toml
+++ b/ballerina/Ballerina.toml
@@ -1,7 +1,7 @@
 [package]
 org = "ballerina"
 name = "websubhub"
-version = "1.2.1"
+version = "1.2.2"
 authors = ["Ballerina"]
 keywords = ["websub", "hub", "publisher", "service", "listener", "client"]
 repository = "https://github.com/ballerina-platform/module-ballerina-websubhub"
@@ -10,4 +10,4 @@ license = ["Apache-2.0"]
 distribution = "2201.0.1"
 
 [[platform.java11.dependency]]
-path = "../native/build/libs/websubhub-native-1.2.1.jar"
+path = "../native/build/libs/websubhub-native-1.2.2-SNAPSHOT.jar"

--- a/ballerina/CompilerPlugin.toml
+++ b/ballerina/CompilerPlugin.toml
@@ -3,4 +3,4 @@ id = "websubhub-compiler-plugin"
 class = "io.ballerina.stdlib.websubhub.WebSubHubCompilerPlugin"
 
 [[dependency]]
-path = "../compiler-plugin/build/libs/websubhub-compiler-plugin-1.2.1.jar"
+path = "../compiler-plugin/build/libs/websubhub-compiler-plugin-1.2.2-SNAPSHOT.jar"

--- a/ballerina/Dependencies.toml
+++ b/ballerina/Dependencies.toml
@@ -313,7 +313,7 @@ modules = [
 [[package]]
 org = "ballerina"
 name = "websubhub"
-version = "1.2.1"
+version = "1.2.2"
 dependencies = [
 	{org = "ballerina", name = "crypto"},
 	{org = "ballerina", name = "http"},

--- a/changelog.md
+++ b/changelog.md
@@ -6,6 +6,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- [Compiler plugin crashes when using a new-expr with a user-defined class in the same source](https://github.com/ballerina-platform/ballerina-standard-library/issues/2815)
+
+## [1.2.0] - 2022-01-29
+
 ### Added
 - [WebSub/WebSubHub should support `readonly` parameters for remote methods](https://github.com/ballerina-platform/ballerina-standard-library/issues/2604)
 

--- a/compiler-plugin-tests/src/test/java/io/ballerina/stdlib/websubhub/CompilerPluginTest.java
+++ b/compiler-plugin-tests/src/test/java/io/ballerina/stdlib/websubhub/CompilerPluginTest.java
@@ -374,10 +374,7 @@ public class CompilerPluginTest {
         Package currentPackage = loadPackage("sample_21");
         PackageCompilation compilation = currentPackage.getCompilation();
         DiagnosticResult diagnosticResult = compilation.diagnosticResult();
-        List<Diagnostic> errorDiagnostics = diagnosticResult.diagnostics().stream()
-                .filter(d -> DiagnosticSeverity.ERROR.equals(d.diagnosticInfo().severity()))
-                .collect(Collectors.toList());
-        Assert.assertEquals(errorDiagnostics.size(), 0);
+        Assert.assertEquals(diagnosticResult.errorCount(), 0);
     }
 
     private void validateErrorsForInvalidReadonlyTypes(WebSubHubDiagnosticCodes expectedCode, Diagnostic diagnostic,

--- a/compiler-plugin-tests/src/test/java/io/ballerina/stdlib/websubhub/CompilerPluginTest.java
+++ b/compiler-plugin-tests/src/test/java/io/ballerina/stdlib/websubhub/CompilerPluginTest.java
@@ -369,6 +369,17 @@ public class CompilerPluginTest {
                 invalidTypeDesc, "onUnsubscription");
     }
 
+    @Test
+    public void testWithNexExprWithUserDefinedClasses() {
+        Package currentPackage = loadPackage("sample_21");
+        PackageCompilation compilation = currentPackage.getCompilation();
+        DiagnosticResult diagnosticResult = compilation.diagnosticResult();
+        List<Diagnostic> errorDiagnostics = diagnosticResult.diagnostics().stream()
+                .filter(d -> DiagnosticSeverity.ERROR.equals(d.diagnosticInfo().severity()))
+                .collect(Collectors.toList());
+        Assert.assertEquals(errorDiagnostics.size(), 0);
+    }
+
     private void validateErrorsForInvalidReadonlyTypes(WebSubHubDiagnosticCodes expectedCode, Diagnostic diagnostic,
                                                        String typeDesc, String remoteMethodName) {
         DiagnosticInfo info = diagnostic.diagnosticInfo();

--- a/compiler-plugin-tests/src/test/resources/ballerina_sources/sample_21/Ballerina.toml
+++ b/compiler-plugin-tests/src/test/resources/ballerina_sources/sample_21/Ballerina.toml
@@ -1,0 +1,7 @@
+[package]
+org = "websubhub_test"
+name = "sample_21"
+version = "0.1.0"
+
+[build-options]
+observabilityIncluded = true

--- a/compiler-plugin-tests/src/test/resources/ballerina_sources/sample_21/main.bal
+++ b/compiler-plugin-tests/src/test/resources/ballerina_sources/sample_21/main.bal
@@ -1,0 +1,24 @@
+// Copyright (c) 2022 WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+//
+// WSO2 Inc. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import ballerina/websubhub as _;
+
+class Foo {
+}
+
+public function main() {
+    _ = new Foo();
+}

--- a/compiler-plugin/src/main/java/io/ballerina/stdlib/websubhub/task/ListenerInitAnalysisTask.java
+++ b/compiler-plugin/src/main/java/io/ballerina/stdlib/websubhub/task/ListenerInitAnalysisTask.java
@@ -55,7 +55,7 @@ public class ListenerInitAnalysisTask implements AnalysisTask<SyntaxNodeAnalysis
         SyntaxKind nodeSyntaxKind = node.kind();
         if (nodeSyntaxKind == SyntaxKind.EXPLICIT_NEW_EXPRESSION) {
             ExplicitNewExpressionNode expressionNode = (ExplicitNewExpressionNode) node;
-            if (!(expressionNode.kind() == SyntaxKind.QUALIFIED_NAME_REFERENCE)) {
+            if (!(expressionNode.typeDescriptor().kind() == SyntaxKind.QUALIFIED_NAME_REFERENCE)) {
                 return;
             }
             QualifiedNameReferenceNode nameRef = (QualifiedNameReferenceNode) expressionNode.typeDescriptor();
@@ -75,6 +75,9 @@ public class ListenerInitAnalysisTask implements AnalysisTask<SyntaxNodeAnalysis
                 ListenerDeclarationNode parentNode = (ListenerDeclarationNode) expressionNode.parent();
                 Optional<TypeDescriptorNode> parentTypeOpt = parentNode.typeDescriptor();
                 if (parentTypeOpt.isPresent()) {
+                    if (!(parentTypeOpt.get().kind() == SyntaxKind.QUALIFIED_NAME_REFERENCE)) {
+                        return;
+                    }
                     QualifiedNameReferenceNode parentType = (QualifiedNameReferenceNode) parentTypeOpt.get();
                     Optional<Symbol> parentSymbolOpt = context.semanticModel().symbol(parentType);
                     if (parentSymbolOpt.isPresent() && parentSymbolOpt.get() instanceof TypeReferenceTypeSymbol) {

--- a/compiler-plugin/src/main/java/io/ballerina/stdlib/websubhub/task/ListenerInitAnalysisTask.java
+++ b/compiler-plugin/src/main/java/io/ballerina/stdlib/websubhub/task/ListenerInitAnalysisTask.java
@@ -55,6 +55,9 @@ public class ListenerInitAnalysisTask implements AnalysisTask<SyntaxNodeAnalysis
         SyntaxKind nodeSyntaxKind = node.kind();
         if (nodeSyntaxKind == SyntaxKind.EXPLICIT_NEW_EXPRESSION) {
             ExplicitNewExpressionNode expressionNode = (ExplicitNewExpressionNode) node;
+            if (!(expressionNode.typeDescriptor() instanceof QualifiedNameReferenceNode)) {
+                return;
+            }
             QualifiedNameReferenceNode nameRef = (QualifiedNameReferenceNode) expressionNode.typeDescriptor();
             Optional<Symbol> symbolOpt = context.semanticModel().symbol(nameRef);
             if (symbolOpt.isPresent() && symbolOpt.get() instanceof TypeReferenceTypeSymbol) {

--- a/compiler-plugin/src/main/java/io/ballerina/stdlib/websubhub/task/ListenerInitAnalysisTask.java
+++ b/compiler-plugin/src/main/java/io/ballerina/stdlib/websubhub/task/ListenerInitAnalysisTask.java
@@ -55,7 +55,7 @@ public class ListenerInitAnalysisTask implements AnalysisTask<SyntaxNodeAnalysis
         SyntaxKind nodeSyntaxKind = node.kind();
         if (nodeSyntaxKind == SyntaxKind.EXPLICIT_NEW_EXPRESSION) {
             ExplicitNewExpressionNode expressionNode = (ExplicitNewExpressionNode) node;
-            if (!(expressionNode.typeDescriptor() instanceof QualifiedNameReferenceNode)) {
+            if (!(expressionNode.kind() == SyntaxKind.QUALIFIED_NAME_REFERENCE)) {
                 return;
             }
             QualifiedNameReferenceNode nameRef = (QualifiedNameReferenceNode) expressionNode.typeDescriptor();


### PR DESCRIPTION
## Purpose
> $subject

Fixes [#2815](https://github.com/ballerina-platform/ballerina-standard-library/issues/2815)

## Examples
N/A

## Checklist
- [X] Linked to an issue
- [X] Updated the changelog
- [X] Added tests
- [ ] ~Updated the spec~
