### PR TITLE
Populate `websubhub:CommonResponse` with all required information

### DIFF
--- a/ballerina/Dependencies.toml
+++ b/ballerina/Dependencies.toml
@@ -233,7 +233,7 @@ dependencies = [
 [[package]]
 org = "ballerina"
 name = "observe"
-version = "1.0.4"
+version = "1.0.5"
 dependencies = [
 	{org = "ballerina", name = "jballerina.java"}
 ]

--- a/ballerina/hub_client.bal
+++ b/ballerina/hub_client.bal
@@ -154,28 +154,24 @@ isolated function generateSignature(string 'key, json|xml|byte[] payload) return
 isolated function processSubscriberResponse(http:Response response, string topic) returns ContentDistributionSuccess|SubscriptionDeletedError|ContentDeliveryError {
     int status = response.statusCode;
     string & readonly responseContentType = response.getContentType();
+    map<string|string[]> responseHeaders = retrieveResponseHeaders(response);
+    string|byte[]|json|xml|map<string>? responsePayload = retrieveResponseBody(response, responseContentType);
     if isSuccessStatusCode(status) {
-        map<string|string[]> responseHeaders = retrieveResponseHeaders(response);
-        if responseContentType.trim().length() > 1 {
-            return {
-                statusCode: status,
-                headers: responseHeaders,
-                mediaType: responseContentType,
-                body: retrieveResponseBody(response, responseContentType)
-            };
-        } else {
-            return {
-                statusCode: status,
-                headers: responseHeaders
-            };
-        }
+        return <ContentDistributionSuccess>{
+            statusCode: status,
+            headers: responseHeaders,
+            mediaType: responseContentType,
+            body: responsePayload
+        };
     } else if status == http:STATUS_GONE {
         // HTTP 410 is used to communicate that subscriber no longer need to continue the subscription
         string errorMsg = string `Subscription to topic [${topic}] is terminated by the subscriber`;
-        return error SubscriptionDeletedError(errorMsg, statusCode = status);
+        return error SubscriptionDeletedError(errorMsg, 
+            statusCode = status, mediaType = responseContentType, body = responsePayload, headers = responseHeaders);
     } else {
         string errorMsg = "Error occurred distributing updated content";
-        return error ContentDeliveryError(errorMsg, body = retrieveResponseBody(response, responseContentType), statusCode = status);
+        return error ContentDeliveryError(errorMsg, 
+            statusCode = status, mediaType = responseContentType, body = responsePayload, headers = responseHeaders);
     }
 }
 

--- a/ballerina/hub_client.bal
+++ b/ballerina/hub_client.bal
@@ -219,7 +219,7 @@ isolated function retrieveResponseBody(http:Response subscriberResponse, string 
         mime:APPLICATION_FORM_URLENCODED => {
             var content = subscriberResponse.getTextPayload();
             if (content is string) {
-                return retrieveResponseBodyForFormUrlEncodedMessage(content);
+                return getFormData(content);
             } 
         }
         _ => {}

--- a/ballerina/hub_client.bal
+++ b/ballerina/hub_client.bal
@@ -154,7 +154,7 @@ isolated function generateSignature(string 'key, json|xml|byte[] payload) return
 isolated function processSubscriberResponse(http:Response response, string topic) returns ContentDistributionSuccess|SubscriptionDeletedError|ContentDeliveryError {
     int status = response.statusCode;
     string & readonly responseContentType = response.getContentType();
-    map<string|string[]> responseHeaders = retrieveResponseHeaders(response);
+    map<string|string[]> responseHeaders = getHeaders(response);
     string|byte[]|json|xml|map<string>? responsePayload = retrieveResponseBody(response, responseContentType);
     if isSuccessStatusCode(status) {
         return <ContentDistributionSuccess>{
@@ -173,21 +173,6 @@ isolated function processSubscriberResponse(http:Response response, string topic
         return error ContentDeliveryError(errorMsg, 
             statusCode = status, mediaType = responseContentType, body = responsePayload, headers = responseHeaders);
     }
-}
-
-isolated function retrieveResponseHeaders(http:Response subscriberResponse) returns map<string|string[]> {
-    map<string|string[]> responseHeaders = {};
-    foreach var headerName in subscriberResponse.getHeaderNames() {
-        string[]|error retrievedValue = subscriberResponse.getHeaders(headerName);
-        if retrievedValue is string[] {
-            if retrievedValue.length() == 1 {
-                responseHeaders[headerName] = retrievedValue[0];
-            } else {
-                responseHeaders[headerName] = retrievedValue;
-            }
-        }
-    }
-    return responseHeaders;
 }
 
 isolated function retrieveResponseBody(http:Response subscriberResponse, string contentType) returns string|byte[]|json|xml|map<string>? {

--- a/ballerina/publisher_client.bal
+++ b/ballerina/publisher_client.bal
@@ -187,20 +187,7 @@ isolated function handleResponse(http:Response response, string topic, string ac
 
 isolated function buildTopicRegistrationChangeRequest(string mode, string topic) returns http:Request {
     http:Request request = new;
-    request.setTextPayload(HUB_MODE + "=" + mode + "&" + HUB_TOPIC + "=" + topic);
+    request.setTextPayload(string `${HUB_MODE}=${mode}&${HUB_TOPIC}=${topic}`);
     request.setHeader(CONTENT_TYPE, mime:APPLICATION_FORM_URLENCODED);
     return request;
-}
-
-isolated function getHeaders(http:Response response) returns map<string|string[]> {
-    string[] headerNames = response.getHeaderNames();
-    map<string|string[]> headers = {};
-    foreach string header in headerNames {
-        string[]|error responseHeaders = response.getHeaders(header);
-        if responseHeaders is string[] {
-            headers[header] = responseHeaders.length() == 1 ? responseHeaders[0] : responseHeaders;
-        }
-        // Not possible to throw header not found
-    }
-    return headers;
 }

--- a/ballerina/publisher_client.bal
+++ b/ballerina/publisher_client.bal
@@ -16,7 +16,6 @@
 
 import ballerina/http;
 import ballerina/mime;
-import ballerina/regex;
 
 # The HTTP based client for WebSub topic registration and deregistration, and notifying the hub of new updates.
 public client class PublisherClient {
@@ -189,30 +188,6 @@ isolated function buildTopicRegistrationChangeRequest(string mode, string topic)
     request.setTextPayload(HUB_MODE + "=" + mode + "&" + HUB_TOPIC + "=" + topic);
     request.setHeader(CONTENT_TYPE, mime:APPLICATION_FORM_URLENCODED);
     return request;
-}
-
-isolated function getFormData(string payload) returns map<string> {
-    map<string> parameters = {};
-    if payload == "" {
-        return parameters;
-    }
-    string[] entries = regex:split(payload, "&");
-    int entryIndex = 0;
-    while (entryIndex < entries.length()) {
-        int? index = entries[entryIndex].indexOf("=");
-        if index is int && index != -1 {
-            string name = entries[entryIndex].substring(0, index);
-            name = name.trim();
-            int size = entries[entryIndex].length();
-            string value = entries[entryIndex].substring(index + 1, size);
-            value = value.trim();
-            if value != "" {
-                parameters[name] = value;
-            }
-        }
-        entryIndex = entryIndex + 1;
-    }
-    return parameters;
 }
 
 isolated function getHeaders(http:Response response) returns map<string|string[]> {

--- a/ballerina/subscription.bal
+++ b/ballerina/subscription.bal
@@ -64,7 +64,7 @@ isolated function processSubscription(Subscription message, http:Headers headers
 isolated function processOnSubscriptionResult(SubscriptionAccepted|error result) returns http:Response|Redirect {
     http:Response response = new;
     if result is SubscriptionAccepted {
-        response.statusCode = http:STATUS_ACCEPTED;
+        updateSuccessResponse(response, result.statusCode, result?.body, result?.headers);
         return response;
     } else if result is BadSubscriptionError {
         CommonResponse errorDetails = result.detail();
@@ -152,7 +152,7 @@ isolated function processUnsubscription(Unsubscription message, http:Headers hea
 isolated function processOnUnsubscriptionResult(UnsubscriptionAccepted|error result) returns http:Response {
     http:Response response = new;
     if result is UnsubscriptionAccepted {
-        response.statusCode = http:STATUS_ACCEPTED;
+        updateSuccessResponse(response, result.statusCode, result?.body, result?.headers);
         return response;
     } else if result is BadUnsubscriptionError {
         CommonResponse errorDetails = result.detail();

--- a/ballerina/tests/additional_error_details_test.bal
+++ b/ballerina/tests/additional_error_details_test.bal
@@ -17,7 +17,6 @@
 import ballerina/log;
 import ballerina/http;
 import ballerina/test;
-import ballerina/regex;
 
 listener Listener hubListenerToAdditionalErrorDetails = new(9093);
 
@@ -114,7 +113,7 @@ function testRegistrationFailureErrorDetails() returns error? {
     http:Response response = check errorDetailsTestClientEp->post("/", request);
     test:assertEquals(response.statusCode, 200);
     string payload = check response.getTextPayload();
-    map<string> responseBody = decodeResponseBody(payload);
+    map<string> responseBody = getFormData(payload);
     test:assertEquals(responseBody["hub.mode"], "denied");
     test:assertEquals(responseBody["hub.reason"], "Topic registration failed!");
     test:assertEquals(responseBody["hub.additional.details"], "Feature is not supported in the hub");
@@ -130,7 +129,7 @@ function testDeregistrationFailureErrorDetails() returns error? {
     http:Response response = check errorDetailsTestClientEp->post("/", request);
     test:assertEquals(response.statusCode, 200);
     string payload = check response.getTextPayload();
-    map<string> responseBody = decodeResponseBody(payload);
+    map<string> responseBody = getFormData(payload);
     test:assertEquals(responseBody["hub.mode"], "denied");
     test:assertEquals(responseBody["hub.reason"], "Topic deregistration failed!");
 }
@@ -145,22 +144,7 @@ function testUpdateMessageErrorDetails() returns error? {
     http:Response response = check errorDetailsTestClientEp->post("/", request);
     test:assertEquals(response.statusCode, 200);
     string payload = check response.getTextPayload();
-    map<string> responseBody = decodeResponseBody(payload);
+    map<string> responseBody = getFormData(payload);
     test:assertEquals(responseBody["hub.mode"], "denied");
     test:assertEquals(responseBody["hub.reason"], "Error in accessing content"); 
 }
-
-isolated function decodeResponseBody(string payload) returns map<string> {
-    map<string> body = {};
-    if (payload.length() > 0) {
-        string[] splittedPayload = regex:split(payload, "&");
-        foreach string bodyPart in splittedPayload {
-            string[] responseComponent =  regex:split(bodyPart, "=");
-            if (responseComponent.length() == 2) {
-                body[responseComponent[0]] = responseComponent[1];
-            }
-        }
-        return body;
-    }
-    return body;
-} 

--- a/ballerina/tests/additional_error_details_test.bal
+++ b/ballerina/tests/additional_error_details_test.bal
@@ -148,3 +148,4 @@ function testUpdateMessageErrorDetails() returns error? {
     test:assertEquals(responseBody["hub.mode"], "denied");
     test:assertEquals(responseBody["hub.reason"], "Error in accessing content"); 
 }
+

--- a/ballerina/tests/utils_test.bal
+++ b/ballerina/tests/utils_test.bal
@@ -286,7 +286,7 @@ function testResponseHeaderRetrievalWithManuallyCreatingHeaders() returns error?
         }
     }
 
-    map<string|string[]> retrievedResponseHeaders = retrieveResponseHeaders(response);
+    map<string|string[]> retrievedResponseHeaders = getHeaders(response);
     test:assertTrue(retrievedResponseHeaders.length() > 0);
     boolean isSuccess = check hasAllHeaders(retrievedResponseHeaders);
     test:assertTrue(isSuccess);
@@ -298,7 +298,7 @@ function testResponseHeaderRetrievalWithManuallyCreatingHeaders() returns error?
 function testResponseHeaderRetrievalWithApiCall() returns error? {
     http:Request request = new;
     http:Response retrievedResponse = check headerRetrievalTestingClient->post("/addHeaders", request);
-    map<string|string[]> retrievedResponseHeaders = retrieveResponseHeaders(retrievedResponse);
+    map<string|string[]> retrievedResponseHeaders = getHeaders(retrievedResponse);
     test:assertTrue(retrievedResponseHeaders.length() > 0);
     boolean isSuccess = check hasAllHeaders(retrievedResponseHeaders);
     test:assertTrue(isSuccess);

--- a/ballerina/tests/utils_test.bal
+++ b/ballerina/tests/utils_test.bal
@@ -412,7 +412,7 @@ isolated function testFormUrlEncodedResponseBodyRetrievalFromQuery() returns err
         "query2": "value2",
         "query3": "value3"
     };
-    map<string> generatedResponseBody = retrieveResponseBodyForFormUrlEncodedMessage("query1=value1&query2=value2&query3=value3");
+    map<string> generatedResponseBody = getFormData("query1=value1&query2=value2&query3=value3");
     test:assertEquals(generatedResponseBody.length(), message.length());
     foreach string 'key in message.keys() {
         _ = generatedResponseBody.remove('key);

--- a/ballerina/topic_registration.bal
+++ b/ballerina/topic_registration.bal
@@ -25,7 +25,7 @@ isolated function processTopicRegistration(http:Headers headers, map<string> par
     TopicRegistrationSuccess|error result = adaptor.callRegisterMethod(msg, headers);
     http:Response response = new;
     if result is TopicRegistrationSuccess {
-        updateSuccessResponse(response, result.statusCode, result["body"], result["headers"]);
+        updateSuccessResponse(response, result.statusCode, result?.body, result?.headers);
     } else {
         CommonResponse errorDetails = result is TopicRegistrationError ? result.detail() : TOPIC_REGISTRATION_ERROR.detail();
         updateErrorResponse(response, errorDetails, result.message());
@@ -42,7 +42,7 @@ isolated function processTopicDeregistration(http:Headers headers, map<string> p
     TopicDeregistrationSuccess|error result = adaptor.callDeregisterMethod(msg, headers);
     http:Response response = new;
     if result is TopicDeregistrationSuccess {
-        updateSuccessResponse(response, result.statusCode, result["body"], result["headers"]);
+        updateSuccessResponse(response, result.statusCode, result?.body, result?.headers);
     } else {
         CommonResponse errorDetails = result is TopicDeregistrationError ? result.detail() : TOPIC_DEREGISTRATION_ERROR.detail();
         updateErrorResponse(response, errorDetails, result.message());

--- a/ballerina/utils.bal
+++ b/ballerina/utils.bal
@@ -110,16 +110,26 @@ isolated function retrieveTextPayloadForFormUrlEncodedMessage(map<string> messag
     return payload;
 }
 
-isolated function retrieveResponseBodyForFormUrlEncodedMessage(string payload) returns map<string> {
-    map<string> responsePayload = {};
+isolated function getFormData(string payload) returns map<string> {
+    map<string> parameters = {};
+    if payload == "" {
+        return parameters;
+    }
     string[] queryParams = regex:split(payload, "&");
-    foreach var query in queryParams {
-        string[] keyValueEntry = regex:split(query, "=");
-        if (keyValueEntry.length() == 2) {
-            responsePayload[keyValueEntry[0]] = keyValueEntry[1];
+    foreach string query in queryParams {
+        int? index = query.indexOf("=");
+        if index is int && index != -1 {
+            string name = query.substring(0, index);
+            name = name.trim();
+            int size = query.length();
+            string value = query.substring(index + 1, size);
+            value = value.trim();
+            if value != "" {
+                parameters[name] = value;
+            }
         }
     }
-    return responsePayload;
+    return parameters;
 }
 
 isolated function retrieveHttpClient(string url, http:ClientConfiguration config) returns http:Client|Error {

--- a/ballerina/utils.bal
+++ b/ballerina/utils.bal
@@ -110,6 +110,18 @@ isolated function retrieveTextPayloadForFormUrlEncodedMessage(map<string> messag
     return payload;
 }
 
+isolated function getHeaders(http:Response response) returns map<string|string[]> {
+    map<string|string[]> responseHeaders = {};
+    foreach string header in response.getHeaderNames() {
+        string[]|error headers = response.getHeaders(header);
+        if headers is string[] {
+            responseHeaders[header] = headers.length() == 1 ? headers[0] : headers;
+        }
+        // Not possible to throw header not found
+    }
+    return responseHeaders;
+}
+
 isolated function getFormData(string payload) returns map<string> {
     map<string> parameters = {};
     if payload == "" {

--- a/changelog.md
+++ b/changelog.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 - [Error responses are not descriptive in `websubhub:PublisherClient`](https://github.com/ballerina-platform/ballerina-standard-library/issues/2919)
+- [`websubhub:CommonResponse` is not properly getting populated for responses](https://github.com/ballerina-platform/ballerina-standard-library/issues/2878)
 
 ## [1.3.0] - 2022-05-30
 


### PR DESCRIPTION
## Purpose
> $subject

`websubhub:CommonResponse` is the base record for all the publisher client and hub client responses. 
It contains following fields:
- statusCode (Mandatory)
- mediaType (Optional)
- body (Optional)
- headers (Optional) 

Apart from a special case where one or more of the above could not be extracted from original HTTP response these fields should be populated properly.

Fixes [#2878](https://github.com/ballerina-platform/ballerina-standard-library/issues/2878)

## Examples
N/A

## Checklist
- [X] Linked to an issue
- [X] Updated the changelog
- [X] Added tests
- [ ] Updated the spec
