### PR TITLE
Add integration test-suite for azure hub deployment

### DIFF
--- a/examples/kafka-hub/integration_test_suite/Ballerina.toml
+++ b/examples/kafka-hub/integration_test_suite/Ballerina.toml
@@ -1,0 +1,7 @@
+[package]
+org = "example"
+name = "kafkaHub.integration_test_suite"
+version = "0.1.0"
+
+[build-options]
+observabilityIncluded = true

--- a/examples/kafka-hub/integration_test_suite/Cloud.toml
+++ b/examples/kafka-hub/integration_test_suite/Cloud.toml
@@ -1,0 +1,11 @@
+[container.image]
+repository="ballerina"
+name="kafkaHub.integration_test_suite"
+tag="v1"
+
+[[container.copy.files]]
+sourceFile="./Config.toml"
+target="/home/ballerina/Config.toml"
+
+[[cloud.config.files]]
+file="./Config.toml"

--- a/examples/kafka-hub/integration_test_suite/Config.toml
+++ b/examples/kafka-hub/integration_test_suite/Config.toml
@@ -6,3 +6,6 @@ TOPIC = "test-topic"
 
 # WebSub `subscriber` callback URL
 CALLBACK_URL = "http://localhost:9090/subscriber"
+
+# File where the results are saved
+RESULTS_FILE_PATH = "results.csv"

--- a/examples/kafka-hub/integration_test_suite/Config.toml
+++ b/examples/kafka-hub/integration_test_suite/Config.toml
@@ -5,7 +5,7 @@ HUB = "http://localhost:9000/hub"
 TOPIC = "test-topic"
 
 # WebSub `subscriber` callback URL
-CALLBACK_URL = "http://localhost:9090/subscriber"
+CALLBACK_URL = "http://localhost:9090"
 
 # File where the results are saved
 RESULTS_FILE_PATH = "results.csv"

--- a/examples/kafka-hub/integration_test_suite/Config.toml
+++ b/examples/kafka-hub/integration_test_suite/Config.toml
@@ -1,0 +1,8 @@
+# WebSub `hub` URL
+HUB = "http://localhost:9000/hub"
+
+# WebSub `topic`
+TOPIC = "test-topic"
+
+# WebSub `subscriber` callback URL
+CALLBACK_URL = "http://localhost:9090/subscriber"

--- a/examples/kafka-hub/integration_test_suite/main.bal
+++ b/examples/kafka-hub/integration_test_suite/main.bal
@@ -47,23 +47,24 @@ public function main() returns error? {
     if subscriptionStatus is error {
         subStatus = "failed";
     } else {
-        runtime:sleep(60);
+        runtime:sleep(90);
         subStatus = isSubscriptionSuccessful() ? "successful" : "failed";
     }
     any[] subscriptionResult = ["SUBSCRIPTION", 1, 1, subStatus];
     testResults.push(subscriptionResult);
 
     int successfulContentPublishCount = publishContent(publisherClientEp);
+    runtime:sleep(90);
     STATUS contentPublishStatus = getReceivedNotificationCount() == successfulContentPublishCount ? "successful" : "failed";
     any[] contentPublishResults = ["CONTENT_PUBLISH", messages.length(), getReceivedNotificationCount(), contentPublishStatus];
     testResults.push(contentPublishResults);
 
-    error? unsubscriptionStatus = subscribe(websubListener, subscriberService);
+    error? unsubscriptionStatus = unsubscribe(websubListener);
     STATUS unubStatus = "successful";
     if unsubscriptionStatus is error {
         unubStatus = "failed";
     } else {
-        runtime:sleep(60);
+        runtime:sleep(90);
         unubStatus = isUnsubscriptionSuccessful() ? "successful" : "failed";
     }
     any[] unsubscriptionResult = ["UNSUBSCRIPTION", 1, 1, unubStatus];

--- a/examples/kafka-hub/integration_test_suite/main.bal
+++ b/examples/kafka-hub/integration_test_suite/main.bal
@@ -1,0 +1,65 @@
+import ballerina/websub;
+import ballerina/websubhub;
+
+configurable string HUB = ?;
+configurable string TOPIC = ?;
+configurable string CALLBACK_URL = ?;
+final string SECRET = "test123$";
+
+final websub:Listener websubListener = check new (9090);
+
+public function main() returns error? {
+    websubhub:PublisherClient publisherClientEp = check new(HUB);
+    websubhub:TopicRegistrationSuccess|error registrationResponse = registerTopic(publisherClientEp);
+    // todo: how to handle the topic-reg success/failure
+
+    error? subscriptionStatus = subscribe(websubListener, subscriberService);
+    // todo: how to handle the subscription success/failure
+    if subscriptionStatus is error {
+
+    }
+
+    websubhub:UpdateMessageError? contentPublishStatus = publishContent(publisherClientEp);
+    // todo: how to handle content publish success/failure
+
+    error? unsubscriptionStatus = subscribe(websubListener, subscriberService);
+    // todo: how to handle unsubscription success/failure
+    if unsubscriptionStatus is error {
+
+    }
+
+    websubhub:TopicDeregistrationSuccess|error deRegistrationResponse = deregisterTopic(publisherClientEp);
+    // todo: how to handle topic-dereg success/failure
+}
+
+isolated function registerTopic(websubhub:PublisherClient publisherClientEp) returns websubhub:TopicRegistrationSuccess|error {
+    return publisherClientEp->registerTopic(TOPIC);
+}
+
+isolated function subscribe(websub:Listener websubListener, websub:SubscriberService subscriberService) returns error? {
+    websub:SubscriberServiceConfiguration config = {
+        target: [HUB, TOPIC],
+        callback: CALLBACK_URL,
+        secret: SECRET,
+        unsubscribeOnShutdown: true
+    };
+    check websubListener.attachWithConfig(subscriberService, config);
+    return websubListener.'start();
+}
+
+isolated function publishContent(websubhub:PublisherClient publisherClientEp) returns websubhub:UpdateMessageError? {
+    foreach json message in messages {
+        var publishResponse = publisherClientEp->publishUpdate(TOPIC, message);
+        if publishResponse is websubhub:UpdateMessageError {
+            return publishResponse;
+        }
+    }
+}
+
+isolated function unsubscribe(websub:Listener websubListener) returns error? {
+    return websubListener.gracefulStop();
+}
+
+isolated function deregisterTopic(websubhub:PublisherClient publisherClientEp) returns websubhub:TopicDeregistrationSuccess|error {
+    return publisherClientEp->deregisterTopic(TOPIC);
+}

--- a/examples/kafka-hub/integration_test_suite/main.bal
+++ b/examples/kafka-hub/integration_test_suite/main.bal
@@ -66,14 +66,14 @@ public function main() returns error? {
     testResults.push(contentPublishResults);
 
     error? unsubscriptionStatus = unsubscribe(websubListener);
-    STATUS unubStatus = SUCCESSFUL;
+    STATUS unSubStatus = SUCCESSFUL;
     if unsubscriptionStatus is error {
-        unubStatus = FAILED;
+        unSubStatus = FAILED;
     } else {
         runtime:sleep(90);
-        unubStatus = isUnsubscriptionSuccessful() ? SUCCESSFUL : FAILED;
+        unSubStatus = isUnsubscriptionSuccessful() ? SUCCESSFUL : FAILED;
     }
-    TEST_RESULT unsubscriptionResult = ["UNSUBSCRIPTION", 1, 1, unubStatus];
+    TEST_RESULT unsubscriptionResult = ["UNSUBSCRIPTION", 1, 1, unSubStatus];
     testResults.push(unsubscriptionResult);
 
     websubhub:TopicDeregistrationSuccess|error deRegistrationResponse = deregisterTopic(publisherClientEp);

--- a/examples/kafka-hub/integration_test_suite/main.bal
+++ b/examples/kafka-hub/integration_test_suite/main.bal
@@ -1,35 +1,86 @@
+// Copyright (c) 2022, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+//
+// WSO2 Inc. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import ballerina/file;
+import ballerina/io;
+import ballerina/lang.runtime;
+import ballerina/log;
 import ballerina/websub;
 import ballerina/websubhub;
 
 configurable string HUB = ?;
 configurable string TOPIC = ?;
 configurable string CALLBACK_URL = ?;
+configurable string RESULTS_FILE_PATH = ?;
 final string SECRET = "test123$";
 
 final websub:Listener websubListener = check new (9090);
+final readonly & json[] messages = [ADD_NEW_USER_MESSAGE, LOGIN_SUCCESS_MESSAGE];
+
+type STATUS "successful" | "failed" | "partial";
+final string[] & readonly documentationCsvHeaders = ["Label", "Sent Count", "Received Count", "Status"];
 
 public function main() returns error? {
+    _ = check initializeTests();
+    any[][] testResults = [];
+
     websubhub:PublisherClient publisherClientEp = check new(HUB);
     websubhub:TopicRegistrationSuccess|error registrationResponse = registerTopic(publisherClientEp);
-    // todo: how to handle the topic-reg success/failure
+    any[] topicRegResult = ["TOPIC_REGISTRATION", 1, 1, registrationResponse is error ? "failed" : "successful"];
+    testResults.push(topicRegResult);
 
     error? subscriptionStatus = subscribe(websubListener, subscriberService);
-    // todo: how to handle the subscription success/failure
+    STATUS subStatus = "successful";
     if subscriptionStatus is error {
-
+        subStatus = "failed";
+    } else {
+        runtime:sleep(60);
+        subStatus = isSubscriptionSuccessful() ? "successful" : "failed";
     }
+    any[] subscriptionResult = ["SUBSCRIPTION", 1, 1, subStatus];
+    testResults.push(subscriptionResult);
 
-    websubhub:UpdateMessageError? contentPublishStatus = publishContent(publisherClientEp);
-    // todo: how to handle content publish success/failure
+    int successfulContentPublishCount = publishContent(publisherClientEp);
+    STATUS contentPublishStatus = getReceivedNotificationCount() == successfulContentPublishCount ? "successful" : "failed";
+    any[] contentPublishResults = ["CONTENT_PUBLISH", messages.length(), getReceivedNotificationCount(), contentPublishStatus];
+    testResults.push(contentPublishResults);
 
     error? unsubscriptionStatus = subscribe(websubListener, subscriberService);
-    // todo: how to handle unsubscription success/failure
+    STATUS unubStatus = "successful";
     if unsubscriptionStatus is error {
-
+        unubStatus = "failed";
+    } else {
+        runtime:sleep(60);
+        unubStatus = isUnsubscriptionSuccessful() ? "successful" : "failed";
     }
+    any[] unsubscriptionResult = ["UNSUBSCRIPTION", 1, 1, unubStatus];
+    testResults.push(unsubscriptionResult);
 
     websubhub:TopicDeregistrationSuccess|error deRegistrationResponse = deregisterTopic(publisherClientEp);
-    // todo: how to handle topic-dereg success/failure
+    any[] topicDeRegResult = ["TOPIC_DEREGISTRATION", 1, 1, deRegistrationResponse is error ? "failed" : "successful"];
+    testResults.push(topicDeRegResult);
+
+    return writeResultsToCsv(testResults, RESULTS_FILE_PATH);
+}
+
+function initializeTests() returns error? {
+    boolean fileExists = check file:test(RESULTS_FILE_PATH, file:EXISTS);
+    if !fileExists {
+        check io:fileWriteCsv(RESULTS_FILE_PATH, [documentationCsvHeaders]);
+    }
 }
 
 isolated function registerTopic(websubhub:PublisherClient publisherClientEp) returns websubhub:TopicRegistrationSuccess|error {
@@ -47,13 +98,16 @@ isolated function subscribe(websub:Listener websubListener, websub:SubscriberSer
     return websubListener.'start();
 }
 
-isolated function publishContent(websubhub:PublisherClient publisherClientEp) returns websubhub:UpdateMessageError? {
+isolated function publishContent(websubhub:PublisherClient publisherClientEp) returns int {
+    int sentCount = 0;
     foreach json message in messages {
+        sentCount += 1;
         var publishResponse = publisherClientEp->publishUpdate(TOPIC, message);
         if publishResponse is websubhub:UpdateMessageError {
-            return publishResponse;
+            log:printWarn("Error occurred while publishing content");
         }
     }
+    return sentCount;
 }
 
 isolated function unsubscribe(websub:Listener websubListener) returns error? {
@@ -62,4 +116,16 @@ isolated function unsubscribe(websub:Listener websubListener) returns error? {
 
 isolated function deregisterTopic(websubhub:PublisherClient publisherClientEp) returns websubhub:TopicDeregistrationSuccess|error {
     return publisherClientEp->deregisterTopic(TOPIC);
+}
+
+isolated function writeResultsToCsv(any[][] results, string output_path) returns error? {
+    string[][] final_results = [];
+    foreach any[] resultLine in results {
+        string[] constructedResultLine = [];
+        foreach var result in resultLine {
+            constructedResultLine.push(result.toString());
+        }
+        final_results.push(constructedResultLine);
+    }
+    check io:fileWriteCsv(output_path, final_results, io:APPEND);
 }

--- a/examples/kafka-hub/integration_test_suite/messages.bal
+++ b/examples/kafka-hub/integration_test_suite/messages.bal
@@ -1,1 +1,59 @@
-final readonly & json[] messages = [];
+// Copyright (c) 2022, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+//
+// WSO2 Inc. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+final readonly & json ADD_NEW_USER_MESSAGE = {
+    "iss": "Asgardeo",
+    "jti": "84d449d92b7f",
+    "iat": 1664254276282,
+    "aud": "https://websubhub/topics/test/REGISTRATIONS",
+    "event": {
+        "urn:ietf:params:registrations:event:addUser": {
+            "ref": "https://dev.api.asgardeo.io/t/test/scim2/Users/user123",
+            "organizationId": 365,
+            "organizationName": "test",
+            "userId": "user123",
+            "userName": "test123@mailinator.com",
+            "userStoreName": "DEFAULT",
+            "userOnboardMethod": "ADMIN_INITIATED",
+            "roleList": [],
+            "claims": {
+                "http://wso2.org/claims/created": "2022-09-27T04:51:16.2393770Z",
+                "http://wso2.org/claims/emailaddress": "test123@mailinator.com",
+                "http://wso2.org/claims/location": "https://dev.api.asgardeo.io/t/test/scim2/Users/user123",
+                "http://wso2.org/claims/lastname": "John",
+                "http://wso2.org/claims/givenname": "Doe"
+            }
+        }
+    }
+};
+
+final readonly & json LOGIN_SUCCESS_MESSAGE = {
+    "iss": "Asgardeo",
+    "jti": "9965a050e94d",
+    "iat": 1664197085083,
+    "aud": "https://websubhub/topics/test/LOGINS",
+    "event": {
+        "urn:ietf:params:logins:event:loginSuccess": {
+            "ref": "https://dev.api.asgardeo.io/scim2/Users/user123",
+            "organizationId": 1610,
+            "organizationName": "test",
+            "userId": "user123",
+            "userName": "test123@mailinator.com",
+            "userStoreName": "DEFAULT",
+            "serviceProvider": "My Account"
+        }
+    }
+};

--- a/examples/kafka-hub/integration_test_suite/messages.bal
+++ b/examples/kafka-hub/integration_test_suite/messages.bal
@@ -1,0 +1,1 @@
+final readonly & json[] messages = [];

--- a/examples/kafka-hub/integration_test_suite/subscriber_service.bal
+++ b/examples/kafka-hub/integration_test_suite/subscriber_service.bal
@@ -1,19 +1,76 @@
+// Copyright (c) 2022, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+//
+// WSO2 Inc. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
 import ballerina/websub;
+
+isolated boolean subscriptionSuccessful = false;
+isolated boolean unsubscriptionSuccessful = false;
+isolated int recievedNotificationCount = 0;
+
+isolated function isSubscriptionSuccessful() returns boolean {
+    lock {
+        return subscriptionSuccessful;
+    }
+}
+
+isolated function isUnsubscriptionSuccessful() returns boolean {
+    lock {
+        return unsubscriptionSuccessful;
+    }
+}
+
+isolated function getReceivedNotificationCount() returns int {
+    lock {
+        return recievedNotificationCount;
+    }
+}
 
 final websub:SubscriberService subscriberService = service object {
     remote function onSubscriptionValidationDenied(websub:SubscriptionDeniedError msg) {
-
+        lock {
+            if !subscriptionSuccessful {
+                subscriptionSuccessful = true;
+                return;
+            }
+        }
+        lock {
+            if !unsubscriptionSuccessful {
+                unsubscriptionSuccessful = true;
+                return;
+            }
+        }
     }
 
     remote function onSubscriptionVerification(websub:SubscriptionVerification msg) returns websub:SubscriptionVerificationSuccess {
+        lock {
+            subscriptionSuccessful = true;
+        }
         return websub:SUBSCRIPTION_VERIFICATION_SUCCESS;
     }
 
     remote function onUnsubscriptionVerification(websub:UnsubscriptionVerification msg) returns websub:UnsubscriptionVerificationSuccess {
+        lock {
+            unsubscriptionSuccessful = true;
+        }
         return websub:UNSUBSCRIPTION_VERIFICATION_SUCCESS;
     }
 
     remote function onEventNotification(websub:ContentDistributionMessage event) {
-
+        lock {
+            recievedNotificationCount += 1;
+        }
     }
 };

--- a/examples/kafka-hub/integration_test_suite/subscriber_service.bal
+++ b/examples/kafka-hub/integration_test_suite/subscriber_service.bal
@@ -1,0 +1,19 @@
+import ballerina/websub;
+
+final websub:SubscriberService subscriberService = service object {
+    remote function onSubscriptionValidationDenied(websub:SubscriptionDeniedError msg) {
+
+    }
+
+    remote function onSubscriptionVerification(websub:SubscriptionVerification msg) returns websub:SubscriptionVerificationSuccess {
+        return websub:SUBSCRIPTION_VERIFICATION_SUCCESS;
+    }
+
+    remote function onUnsubscriptionVerification(websub:UnsubscriptionVerification msg) returns websub:UnsubscriptionVerificationSuccess {
+        return websub:UNSUBSCRIPTION_VERIFICATION_SUCCESS;
+    }
+
+    remote function onEventNotification(websub:ContentDistributionMessage event) {
+
+    }
+};


### PR DESCRIPTION
## Purpose
> $subject

Part of [#3392](https://github.com/ballerina-platform/ballerina-standard-library/issues/3392) 

## Examples
When running integration tests, following configurations should be updated in the `Config.toml`:
- HUB
- TOPIC
- CALLBACK_URL
- RESULTS_FILE_PATH

After running tests there will be a `result.csv` generated at `RESULTS_FILE_PATH`. It has following structure:
|Label               |Sent Count|Received Count|Status    |
|--------------------|----------|--------------|----------|
|TOPIC_REGISTRATION  |1         |1             |SUCCESSFUL|
|SUBSCRIPTION        |1         |1             |SUCCESSFUL|
|CONTENT_PUBLISH     |2         |2             |SUCCESSFUL|
|UNSUBSCRIPTION      |1         |1             |SUCCESSFUL|
|TOPIC_DEREGISTRATION|1         |1             |SUCCESSFUL|

All the event-types should be `SUCCESSFUL` in order to identify that the test-suite was completed successfully.

## Checklist
- [X] Linked to an issue
- [ ] ~Updated the changelog~
- [ ] ~Added tests~
- [ ] ~Updated the spec~
