### PR TITLE
[2201.2.x] Fix logic in `websubhub:HubClient` not to append unwanted `/` in the service-path

### DIFF
--- a/ballerina/Ballerina.toml
+++ b/ballerina/Ballerina.toml
@@ -1,7 +1,7 @@
 [package]
 org = "ballerina"
 name = "websubhub"
-version = "1.4.0"
+version = "1.4.1"
 authors = ["Ballerina"]
 keywords = ["websub", "hub", "publisher", "service", "listener", "client"]
 repository = "https://github.com/ballerina-platform/module-ballerina-websubhub"
@@ -12,5 +12,5 @@ distribution = "2201.2.0"
 [[platform.java11.dependency]]
 groupId = "io.ballerina.stdlib"
 artifactId = "websubhub-native"
-version = "1.4.0"
-path = "../native/build/libs/websubhub-native-1.4.0.jar"
+version = "1.4.1"
+path = "../native/build/libs/websubhub-native-1.4.1-SNAPSHOT.jar"

--- a/ballerina/CompilerPlugin.toml
+++ b/ballerina/CompilerPlugin.toml
@@ -3,4 +3,4 @@ id = "websubhub-compiler-plugin"
 class = "io.ballerina.stdlib.websubhub.WebSubHubCompilerPlugin"
 
 [[dependency]]
-path = "../compiler-plugin/build/libs/websubhub-compiler-plugin-1.4.0.jar"
+path = "../compiler-plugin/build/libs/websubhub-compiler-plugin-1.4.1-SNAPSHOT.jar"

--- a/ballerina/Dependencies.toml
+++ b/ballerina/Dependencies.toml
@@ -203,7 +203,7 @@ dependencies = [
 [[package]]
 org = "ballerina"
 name = "log"
-version = "2.4.0"
+version = "2.4.1"
 dependencies = [
 	{org = "ballerina", name = "io"},
 	{org = "ballerina", name = "jballerina.java"},
@@ -326,7 +326,7 @@ modules = [
 [[package]]
 org = "ballerina"
 name = "websubhub"
-version = "1.4.0"
+version = "1.4.1"
 dependencies = [
 	{org = "ballerina", name = "crypto"},
 	{org = "ballerina", name = "http"},

--- a/ballerina/hub_client.bal
+++ b/ballerina/hub_client.bal
@@ -92,7 +92,7 @@ public client class HubClient {
                     "Error retrieving content signature", hash, statusCode = http:STATUS_BAD_REQUEST);
             }
         }
-        http:Response|error response = self.httpClient->post("/", request);
+        http:Response|error response = self.httpClient->post("", request);
         if response is http:Response {
             return processSubscriberResponse(response, self.topic);
         } else {

--- a/changelog.md
+++ b/changelog.md
@@ -6,6 +6,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- [`websubhub:HubClient` appends unwanted `/` to the service-path](https://github.com/ballerina-platform/ballerina-standard-library/issues/3564)
+
+## [1.4.0] - 2022-09-08
+
 ### Added
 - [Add `statusCode` field for `CommonResponse`](https://github.com/ballerina-platform/ballerina-standard-library/issues/2879)
 


### PR DESCRIPTION
## Purpose
> $subject

Fixes [#3564](https://github.com/ballerina-platform/ballerina-standard-library/issues/3564)

## Examples
N/A

## Checklist
- [X] Linked to an issue
- [X] Updated the changelog
- [X] Added tests
- [ ] ~Updated the spec~
- [ ] ~Checked native-image compatibility~
