### PR TITLE
[FIX] Compiler plugin validation logic for `websubhub:Listener` args when a `check` expression is present

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Fixed
-- [Compiler Plugin Allows Passing an HTTP Listener with Configs to Listener Init](https://github.com/ballerina-platform/ballerina-standard-library/issues/2782)
+- [Compiler plugin allows passing an HTTP listener with configs to listener init](https://github.com/ballerina-platform/ballerina-standard-library/issues/2782)
 
 ### Changed
 - [API Docs Updated](https://github.com/ballerina-platform/ballerina-standard-library/issues/3463)

--- a/changelog.md
+++ b/changelog.md
@@ -6,6 +6,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- [Compiler Plugin Allows Passing an HTTP Listener with Configs to Listener Init](https://github.com/ballerina-platform/ballerina-standard-library/issues/2782)
+
 ### Changed
 - [API Docs Updated](https://github.com/ballerina-platform/ballerina-standard-library/issues/3463)
 

--- a/compiler-plugin-tests/src/test/java/io/ballerina/stdlib/websubhub/CompilerPluginTest.java
+++ b/compiler-plugin-tests/src/test/java/io/ballerina/stdlib/websubhub/CompilerPluginTest.java
@@ -377,6 +377,22 @@ public class CompilerPluginTest {
         Assert.assertEquals(diagnosticResult.errorCount(), 0);
     }
 
+    @Test
+    public void testCompilerPluginForListenerImplicitInitWithCheckExpr() {
+        Package currentPackage = loadPackage("sample_22");
+        PackageCompilation compilation = currentPackage.getCompilation();
+        DiagnosticResult diagnosticResult = compilation.diagnosticResult();
+        List<Diagnostic> errorDiagnostics = diagnosticResult.diagnostics().stream()
+                .filter(d -> DiagnosticSeverity.ERROR.equals(d.diagnosticInfo().severity()))
+                .collect(Collectors.toList());
+        Assert.assertEquals(errorDiagnostics.size(), 1);
+        Diagnostic diagnostic = (Diagnostic) errorDiagnostics.toArray()[0];
+        DiagnosticInfo diagnosticInfo = diagnostic.diagnosticInfo();
+        WebSubHubDiagnosticCodes expectedCode = WebSubHubDiagnosticCodes.WEBSUBHUB_101;
+        Assert.assertNotNull(diagnosticInfo, "DiagnosticInfo is null for erroneous service definition");
+        Assert.assertEquals(diagnosticInfo.code(), expectedCode.getCode());
+        Assert.assertEquals(diagnostic.message(), expectedCode.getDescription());
+    }
     private void validateErrorsForInvalidReadonlyTypes(WebSubHubDiagnosticCodes expectedCode, Diagnostic diagnostic,
                                                        String typeDesc, String remoteMethodName) {
         DiagnosticInfo info = diagnostic.diagnosticInfo();

--- a/compiler-plugin-tests/src/test/resources/ballerina_sources/sample_22/Ballerina.toml
+++ b/compiler-plugin-tests/src/test/resources/ballerina_sources/sample_22/Ballerina.toml
@@ -1,0 +1,7 @@
+[package]
+org = "websubhub_test"
+name = "sample_22"
+version = "0.1.0"
+
+[build-options]
+observabilityIncluded = true

--- a/compiler-plugin-tests/src/test/resources/ballerina_sources/sample_22/service.bal
+++ b/compiler-plugin-tests/src/test/resources/ballerina_sources/sample_22/service.bal
@@ -1,6 +1,6 @@
-// Copyright (c) 2021 WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+// Copyright (c) 2022 WSO2 LLC. (http://www.wso2.com) All Rights Reserved.
 //
-// WSO2 Inc. licenses this file to you under the Apache License,
+// WSO2 LLC. licenses this file to you under the Apache License,
 // Version 2.0 (the "License"); you may not use this file except
 // in compliance with the License.
 // You may obtain a copy of the License at

--- a/compiler-plugin-tests/src/test/resources/ballerina_sources/sample_22/service.bal
+++ b/compiler-plugin-tests/src/test/resources/ballerina_sources/sample_22/service.bal
@@ -27,10 +27,12 @@ listener websubhub:Listener functionWithArgumentsListener = check new(httpListen
     }
 });
 
+final readonly & string[] TOPICS = ["test", "test1"];
+
 service /websubhub on functionWithArgumentsListener {
     isolated remote function onRegisterTopic(websubhub:TopicRegistration message)
                                 returns websubhub:TopicRegistrationSuccess|websubhub:TopicRegistrationError {
-        if message.topic == "test" {
+        if TOPICS.indexOf(message.topic) is () {
             return websubhub:TOPIC_REGISTRATION_SUCCESS;
         } else {
             return websubhub:TOPIC_REGISTRATION_ERROR;
@@ -39,58 +41,44 @@ service /websubhub on functionWithArgumentsListener {
 
     isolated remote function onDeregisterTopic(websubhub:TopicDeregistration message)
                         returns websubhub:TopicDeregistrationSuccess|websubhub:TopicDeregistrationError {
-        if message.topic == "test" {
+        if TOPICS.indexOf(message.topic) !is () {
             return websubhub:TOPIC_DEREGISTRATION_SUCCESS;
        } else {
             return websubhub:TOPIC_DEREGISTRATION_ERROR;
         }
     }
 
-    isolated remote function onUpdateMessage(websubhub:UpdateMessage msg)
+    isolated remote function onUpdateMessage(websubhub:UpdateMessage message)
                returns websubhub:Acknowledgement|websubhub:UpdateMessageError {
-        if msg.hubTopic == "test" {
-            return websubhub:ACKNOWLEDGEMENT;
-        } else if msg.content !is () {
+        if TOPICS.indexOf(message.hubTopic) !is () {
             return websubhub:ACKNOWLEDGEMENT;
         } else {
             return websubhub:UPDATE_MESSAGE_ERROR;
         }
     }
     
-    isolated remote function onSubscription(websubhub:Subscription msg)
-                returns websubhub:SubscriptionAccepted|websubhub:SubscriptionPermanentRedirect|websubhub:SubscriptionTemporaryRedirect
-                |websubhub:BadSubscriptionError|websubhub:InternalSubscriptionError {
-        if msg.hubTopic == "test" {
-            return websubhub:SUBSCRIPTION_ACCEPTED;
-        } else if msg.hubTopic == "test1" {
-            return websubhub:SUBSCRIPTION_ACCEPTED;
-        } else {
-            return websubhub:BAD_SUBSCRIPTION_ERROR;
-        }
+    isolated remote function onSubscription(websubhub:Subscription message) returns websubhub:SubscriptionAccepted {
+        return websubhub:SUBSCRIPTION_ACCEPTED;
     }
 
-    isolated remote function onSubscriptionValidation(websubhub:Subscription msg)
+    isolated remote function onSubscriptionValidation(websubhub:Subscription message)
                 returns websubhub:SubscriptionDeniedError? {
-        if msg.hubTopic == "test1" {
+        if TOPICS.indexOf(message.hubTopic) is () {
             return websubhub:SUBSCRIPTION_DENIED_ERROR;
         }
         return;
     }
 
-    isolated remote function onSubscriptionIntentVerified(websubhub:VerifiedSubscription msg) {}
+    isolated remote function onSubscriptionIntentVerified(websubhub:VerifiedSubscription message) {}
 
-    isolated remote function onUnsubscription(websubhub:Unsubscription msg)
-               returns websubhub:UnsubscriptionAccepted|websubhub:BadUnsubscriptionError|websubhub:InternalUnsubscriptionError {
-        if msg.hubTopic == "test" || msg.hubTopic == "test1" {
-            return websubhub:UNSUBSCRIPTION_ACCEPTED;
-        } else {
-            return websubhub:BAD_UNSUBSCRIPTION_ERROR;
-        }
+    isolated remote function onUnsubscription(websubhub:Unsubscription message) 
+                returns websubhub:UnsubscriptionAccepted {
+        return websubhub:UNSUBSCRIPTION_ACCEPTED;
     }
 
-    isolated remote function onUnsubscriptionValidation(websubhub:Unsubscription msg)
+    isolated remote function onUnsubscriptionValidation(websubhub:Unsubscription message)
                 returns websubhub:UnsubscriptionDeniedError? {
-        if msg.hubTopic == "test1" {
+        if TOPICS.indexOf(message.hubTopic) !is () {
             return websubhub:UNSUBSCRIPTION_DENIED_ERROR;
         }
         return;

--- a/compiler-plugin-tests/src/test/resources/ballerina_sources/sample_22/service.bal
+++ b/compiler-plugin-tests/src/test/resources/ballerina_sources/sample_22/service.bal
@@ -1,0 +1,105 @@
+// Copyright (c) 2021 WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+//
+// WSO2 Inc. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import ballerina/websubhub;
+import ballerina/http;
+import ballerina/io;
+
+listener http:Listener httpListener = new http:Listener(10012);
+listener websubhub:Listener functionWithArgumentsListener = check new(httpListener, {
+    secureSocket: {
+        key: {
+            path: "tests/resources/ballerinaKeystore.pkcs12",
+            password: "ballerina"
+        }
+    }
+});
+
+service /websubhub on functionWithArgumentsListener {
+    isolated remote function onRegisterTopic(websubhub:TopicRegistration message)
+                                returns websubhub:TopicRegistrationSuccess|websubhub:TopicRegistrationError {
+        if (message.topic == "test") {
+            return websubhub:TOPIC_REGISTRATION_SUCCESS;
+        } else {
+            return websubhub:TOPIC_REGISTRATION_ERROR;
+        }
+    }
+
+    isolated remote function onDeregisterTopic(websubhub:TopicDeregistration message)
+                        returns websubhub:TopicDeregistrationSuccess|websubhub:TopicDeregistrationError {
+        if (message.topic == "test") {
+            return websubhub:TOPIC_DEREGISTRATION_SUCCESS;
+       } else {
+            return websubhub:TOPIC_DEREGISTRATION_ERROR;
+        }
+    }
+
+    isolated remote function onUpdateMessage(websubhub:UpdateMessage msg)
+               returns websubhub:Acknowledgement|websubhub:UpdateMessageError {
+        if (msg.hubTopic == "test") {
+            return websubhub:ACKNOWLEDGEMENT;
+        } else if (!(msg.content is ())) {
+            return websubhub:ACKNOWLEDGEMENT;
+        } else {
+            return websubhub:UPDATE_MESSAGE_ERROR;
+        }
+    }
+    
+    isolated remote function onSubscription(websubhub:Subscription msg)
+                returns websubhub:SubscriptionAccepted|websubhub:SubscriptionPermanentRedirect|websubhub:SubscriptionTemporaryRedirect
+                |websubhub:BadSubscriptionError|websubhub:InternalSubscriptionError {
+        if (msg.hubTopic == "test") {
+            return websubhub:SUBSCRIPTION_ACCEPTED;
+        } else if (msg.hubTopic == "test1") {
+            return websubhub:SUBSCRIPTION_ACCEPTED;
+        } else {
+            return websubhub:BAD_SUBSCRIPTION_ERROR;
+        }
+    }
+
+    isolated remote function onSubscriptionValidation(websubhub:Subscription msg)
+                returns websubhub:SubscriptionDeniedError? {
+        if (msg.hubTopic == "test1") {
+            return websubhub:SUBSCRIPTION_DENIED_ERROR;
+        }
+        return ();
+    }
+
+    isolated remote function onSubscriptionIntentVerified(websubhub:VerifiedSubscription msg) {
+        io:println("Subscription Intent verified invoked!");
+    }
+
+    isolated remote function onUnsubscription(websubhub:Unsubscription msg)
+               returns websubhub:UnsubscriptionAccepted|websubhub:BadUnsubscriptionError|websubhub:InternalUnsubscriptionError {
+        if (msg.hubTopic == "test" || msg.hubTopic == "test1" ) {
+            return websubhub:UNSUBSCRIPTION_ACCEPTED;
+        } else {
+            return websubhub:BAD_UNSUBSCRIPTION_ERROR;
+        }
+    }
+
+    isolated remote function onUnsubscriptionValidation(websubhub:Unsubscription msg)
+                returns websubhub:UnsubscriptionDeniedError? {
+        if (msg.hubTopic == "test1") {
+            return websubhub:UNSUBSCRIPTION_DENIED_ERROR;
+        }
+        return ();
+    }
+
+    isolated remote function onUnsubscriptionIntentVerified(websubhub:VerifiedUnsubscription msg){
+        io:println("Unsubscription Intent verified invoked!");
+    }
+}

--- a/compiler-plugin-tests/src/test/resources/ballerina_sources/sample_22/service.bal
+++ b/compiler-plugin-tests/src/test/resources/ballerina_sources/sample_22/service.bal
@@ -16,7 +16,6 @@
 
 import ballerina/websubhub;
 import ballerina/http;
-import ballerina/io;
 
 listener http:Listener httpListener = new http:Listener(10012);
 listener websubhub:Listener functionWithArgumentsListener = check new(httpListener, {
@@ -31,7 +30,7 @@ listener websubhub:Listener functionWithArgumentsListener = check new(httpListen
 service /websubhub on functionWithArgumentsListener {
     isolated remote function onRegisterTopic(websubhub:TopicRegistration message)
                                 returns websubhub:TopicRegistrationSuccess|websubhub:TopicRegistrationError {
-        if (message.topic == "test") {
+        if message.topic == "test" {
             return websubhub:TOPIC_REGISTRATION_SUCCESS;
         } else {
             return websubhub:TOPIC_REGISTRATION_ERROR;
@@ -40,7 +39,7 @@ service /websubhub on functionWithArgumentsListener {
 
     isolated remote function onDeregisterTopic(websubhub:TopicDeregistration message)
                         returns websubhub:TopicDeregistrationSuccess|websubhub:TopicDeregistrationError {
-        if (message.topic == "test") {
+        if message.topic == "test" {
             return websubhub:TOPIC_DEREGISTRATION_SUCCESS;
        } else {
             return websubhub:TOPIC_DEREGISTRATION_ERROR;
@@ -49,9 +48,9 @@ service /websubhub on functionWithArgumentsListener {
 
     isolated remote function onUpdateMessage(websubhub:UpdateMessage msg)
                returns websubhub:Acknowledgement|websubhub:UpdateMessageError {
-        if (msg.hubTopic == "test") {
+        if msg.hubTopic == "test" {
             return websubhub:ACKNOWLEDGEMENT;
-        } else if (!(msg.content is ())) {
+        } else if msg.content !is () {
             return websubhub:ACKNOWLEDGEMENT;
         } else {
             return websubhub:UPDATE_MESSAGE_ERROR;
@@ -61,9 +60,9 @@ service /websubhub on functionWithArgumentsListener {
     isolated remote function onSubscription(websubhub:Subscription msg)
                 returns websubhub:SubscriptionAccepted|websubhub:SubscriptionPermanentRedirect|websubhub:SubscriptionTemporaryRedirect
                 |websubhub:BadSubscriptionError|websubhub:InternalSubscriptionError {
-        if (msg.hubTopic == "test") {
+        if msg.hubTopic == "test" {
             return websubhub:SUBSCRIPTION_ACCEPTED;
-        } else if (msg.hubTopic == "test1") {
+        } else if msg.hubTopic == "test1" {
             return websubhub:SUBSCRIPTION_ACCEPTED;
         } else {
             return websubhub:BAD_SUBSCRIPTION_ERROR;
@@ -72,19 +71,17 @@ service /websubhub on functionWithArgumentsListener {
 
     isolated remote function onSubscriptionValidation(websubhub:Subscription msg)
                 returns websubhub:SubscriptionDeniedError? {
-        if (msg.hubTopic == "test1") {
+        if msg.hubTopic == "test1" {
             return websubhub:SUBSCRIPTION_DENIED_ERROR;
         }
-        return ();
+        return;
     }
 
-    isolated remote function onSubscriptionIntentVerified(websubhub:VerifiedSubscription msg) {
-        io:println("Subscription Intent verified invoked!");
-    }
+    isolated remote function onSubscriptionIntentVerified(websubhub:VerifiedSubscription msg) {}
 
     isolated remote function onUnsubscription(websubhub:Unsubscription msg)
                returns websubhub:UnsubscriptionAccepted|websubhub:BadUnsubscriptionError|websubhub:InternalUnsubscriptionError {
-        if (msg.hubTopic == "test" || msg.hubTopic == "test1" ) {
+        if msg.hubTopic == "test" || msg.hubTopic == "test1" {
             return websubhub:UNSUBSCRIPTION_ACCEPTED;
         } else {
             return websubhub:BAD_UNSUBSCRIPTION_ERROR;
@@ -93,13 +90,11 @@ service /websubhub on functionWithArgumentsListener {
 
     isolated remote function onUnsubscriptionValidation(websubhub:Unsubscription msg)
                 returns websubhub:UnsubscriptionDeniedError? {
-        if (msg.hubTopic == "test1") {
+        if msg.hubTopic == "test1" {
             return websubhub:UNSUBSCRIPTION_DENIED_ERROR;
         }
-        return ();
+        return;
     }
 
-    isolated remote function onUnsubscriptionIntentVerified(websubhub:VerifiedUnsubscription msg){
-        io:println("Unsubscription Intent verified invoked!");
-    }
+    isolated remote function onUnsubscriptionIntentVerified(websubhub:VerifiedUnsubscription msg){}
 }

--- a/compiler-plugin-tests/src/test/resources/ballerina_sources/sample_22/service.bal
+++ b/compiler-plugin-tests/src/test/resources/ballerina_sources/sample_22/service.bal
@@ -69,9 +69,10 @@ service /websubhub on functionWithArgumentsListener {
         return;
     }
 
-    isolated remote function onSubscriptionIntentVerified(websubhub:VerifiedSubscription message) {}
+    isolated remote function onSubscriptionIntentVerified(websubhub:VerifiedSubscription message) {
+    }
 
-    isolated remote function onUnsubscription(websubhub:Unsubscription message) 
+    isolated remote function onUnsubscription(websubhub:Unsubscription message)
                 returns websubhub:UnsubscriptionAccepted {
         return websubhub:UNSUBSCRIPTION_ACCEPTED;
     }
@@ -84,5 +85,6 @@ service /websubhub on functionWithArgumentsListener {
         return;
     }
 
-    isolated remote function onUnsubscriptionIntentVerified(websubhub:VerifiedUnsubscription msg){}
+    isolated remote function onUnsubscriptionIntentVerified(websubhub:VerifiedUnsubscription msg) {
+    }
 }

--- a/compiler-plugin/src/main/java/io/ballerina/stdlib/websubhub/task/AnalyserUtils.java
+++ b/compiler-plugin/src/main/java/io/ballerina/stdlib/websubhub/task/AnalyserUtils.java
@@ -52,6 +52,9 @@ public final class AnalyserUtils {
     }
 
     public static boolean isWebSubHubListener(TypeSymbol listenerType) {
+        if (listenerType.getName().isEmpty() || !Constants.LISTENER_IDENTIFIER.equals(listenerType.getName().get())) {
+            return false;
+        }
         if (listenerType.typeKind() == TypeDescKind.UNION) {
             return ((UnionTypeSymbol) listenerType).memberTypeDescriptors().stream()
                     .filter(typeDescriptor -> typeDescriptor instanceof TypeReferenceTypeSymbol)
@@ -61,17 +64,14 @@ public final class AnalyserUtils {
                                     && isWebSubHub(typeReferenceTypeSymbol.getModule().get()
                             ));
         }
-
         if (listenerType.typeKind() == TypeDescKind.TYPE_REFERENCE) {
             Optional<ModuleSymbol> moduleOpt = ((TypeReferenceTypeSymbol) listenerType).typeDescriptor().getModule();
             return moduleOpt.isPresent() && isWebSubHub(moduleOpt.get());
         }
-
         if (listenerType.typeKind() == TypeDescKind.OBJECT) {
             Optional<ModuleSymbol> moduleOpt = listenerType.getModule();
             return moduleOpt.isPresent() && isWebSubHub(moduleOpt.get());
         }
-
         return false;
     }
 

--- a/compiler-plugin/src/main/java/io/ballerina/stdlib/websubhub/task/AnalyserUtils.java
+++ b/compiler-plugin/src/main/java/io/ballerina/stdlib/websubhub/task/AnalyserUtils.java
@@ -40,7 +40,7 @@ import java.util.List;
 import java.util.Optional;
 
 /**
- * {@code ValidatorUtils} contains utility functions required for {@code websubhub:Service} validation.
+ * {@code AnalyserUtils} contains utility functions required for {@code websubhub:Service} validation.
  */
 public final class AnalyserUtils {
     public static void updateContext(SyntaxNodeAnalysisContext context, WebSubHubDiagnosticCodes errorCode,
@@ -52,27 +52,27 @@ public final class AnalyserUtils {
     }
 
     public static boolean isWebSubHubListener(TypeSymbol listenerType) {
-        if (listenerType.getName().isEmpty() || !Constants.LISTENER_IDENTIFIER.equals(listenerType.getName().get())) {
-            return false;
-        }
         if (listenerType.typeKind() == TypeDescKind.UNION) {
             return ((UnionTypeSymbol) listenerType).memberTypeDescriptors().stream()
                     .filter(typeDescriptor -> typeDescriptor instanceof TypeReferenceTypeSymbol)
                     .map(typeReferenceTypeSymbol -> (TypeReferenceTypeSymbol) typeReferenceTypeSymbol)
-                    .anyMatch(typeReferenceTypeSymbol ->
-                            typeReferenceTypeSymbol.getModule().isPresent()
-                                    && isWebSubHub(typeReferenceTypeSymbol.getModule().get()
-                            ));
+                    .anyMatch(AnalyserUtils::isWebSubListenerType);
         }
         if (listenerType.typeKind() == TypeDescKind.TYPE_REFERENCE) {
-            Optional<ModuleSymbol> moduleOpt = ((TypeReferenceTypeSymbol) listenerType).typeDescriptor().getModule();
-            return moduleOpt.isPresent() && isWebSubHub(moduleOpt.get());
+            return isWebSubListenerType((TypeReferenceTypeSymbol) listenerType);
         }
         if (listenerType.typeKind() == TypeDescKind.OBJECT) {
             Optional<ModuleSymbol> moduleOpt = listenerType.getModule();
             return moduleOpt.isPresent() && isWebSubHub(moduleOpt.get());
         }
         return false;
+    }
+
+    private static boolean isWebSubListenerType(TypeReferenceTypeSymbol typeSymbol) {
+        if (typeSymbol.getName().isEmpty() || !Constants.LISTENER_IDENTIFIER.equals(typeSymbol.getName().get())) {
+            return false;
+        }
+        return typeSymbol.getModule().isPresent() && isWebSubHub(typeSymbol.getModule().get());
     }
 
     public static boolean isWebSubHub(ModuleSymbol moduleSymbol) {

--- a/compiler-plugin/src/main/java/io/ballerina/stdlib/websubhub/task/AnalyserUtils.java
+++ b/compiler-plugin/src/main/java/io/ballerina/stdlib/websubhub/task/AnalyserUtils.java
@@ -56,10 +56,10 @@ public final class AnalyserUtils {
             return ((UnionTypeSymbol) listenerType).memberTypeDescriptors().stream()
                     .filter(typeDescriptor -> typeDescriptor instanceof TypeReferenceTypeSymbol)
                     .map(typeReferenceTypeSymbol -> (TypeReferenceTypeSymbol) typeReferenceTypeSymbol)
-                    .anyMatch(AnalyserUtils::isWebSubListenerType);
+                    .anyMatch(AnalyserUtils::isWebSubHubListenerType);
         }
         if (listenerType.typeKind() == TypeDescKind.TYPE_REFERENCE) {
-            return isWebSubListenerType((TypeReferenceTypeSymbol) listenerType);
+            return isWebSubHubListenerType((TypeReferenceTypeSymbol) listenerType);
         }
         if (listenerType.typeKind() == TypeDescKind.OBJECT) {
             Optional<ModuleSymbol> moduleOpt = listenerType.getModule();
@@ -68,7 +68,7 @@ public final class AnalyserUtils {
         return false;
     }
 
-    private static boolean isWebSubListenerType(TypeReferenceTypeSymbol typeSymbol) {
+    private static boolean isWebSubHubListenerType(TypeReferenceTypeSymbol typeSymbol) {
         if (typeSymbol.getName().isEmpty() || !Constants.LISTENER_IDENTIFIER.equals(typeSymbol.getName().get())) {
             return false;
         }


### PR DESCRIPTION
## Purpose
> $subject

Part of [#2782](https://github.com/ballerina-platform/ballerina-standard-library/issues/2782)

## Examples
N/A

## Checklist
- [X] Linked to an issue
- [X] Updated the changelog
- [X] Added tests
- [ ] ~Updated the spec~
- [ ] ~Checked native-image compatibility~
