### PR TITLE
[Main] Fix logic issue in `ServiceExecutionError` not getting properly populated with error details when there is a `panic` from within the `websubhub:Service`

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -4,7 +4,9 @@ This file contains all the notable changes done to the Ballerina WebSubHub packa
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [1.5.0] - 2022-11-29
+## [Unreleased]
+
+## [1.5.1] - 2023-03-16
 
 ### Fixed
 - [Ballerina `websubhub` module will fail to provide error details properly when there is a `panic` from within the `websubhub:Service`](https://github.com/ballerina-platform/ballerina-standard-library/issues/4217)

--- a/changelog.md
+++ b/changelog.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [1.5.0] - 2022-11-29
 
 ### Fixed
+- [Ballerina `websubhub` module will fail to provide error details properly when there is a `panic` from within the `websubhub:Service`](https://github.com/ballerina-platform/ballerina-standard-library/issues/4217)
+
+## [1.5.0] - 2022-11-29
+
+### Fixed
 - [Compiler plugin allows passing an HTTP listener with configs to listener init](https://github.com/ballerina-platform/ballerina-standard-library/issues/2782)
 
 ### Changed

--- a/native/src/main/java/io/ballerina/stdlib/websubhub/Constants.java
+++ b/native/src/main/java/io/ballerina/stdlib/websubhub/Constants.java
@@ -36,4 +36,9 @@ public interface Constants {
     String ON_UNSUBSCRIPTION = "onUnsubscription";
     String ON_UNSUBSCRIPTION_VALIDATION = "onUnsubscriptionValidation";
     String ON_UNSUBSCRIPTION_INTENT_VERIFIED = "onUnsubscriptionIntentVerified";
+
+    String COMMON_RESPONSE = "CommonResponse";
+    String STATUS_CODE = "statusCode";
+    String SERVICE_EXECUTION_ERROR = "ServiceExecutionError";
+    int PANIC_FROM_THE_SERVICE_ERROR = -6;
 }

--- a/native/src/main/java/io/ballerina/stdlib/websubhub/HubCallback.java
+++ b/native/src/main/java/io/ballerina/stdlib/websubhub/HubCallback.java
@@ -22,11 +22,19 @@ import io.ballerina.runtime.api.Future;
 import io.ballerina.runtime.api.Module;
 import io.ballerina.runtime.api.async.Callback;
 import io.ballerina.runtime.api.creators.ErrorCreator;
+import io.ballerina.runtime.api.creators.ValueCreator;
 import io.ballerina.runtime.api.types.Type;
 import io.ballerina.runtime.api.values.BError;
+import io.ballerina.runtime.api.values.BMap;
 import io.ballerina.runtime.api.values.BString;
 
+import java.util.Map;
+
 import static io.ballerina.runtime.api.utils.StringUtils.fromString;
+import static io.ballerina.stdlib.websubhub.Constants.COMMON_RESPONSE;
+import static io.ballerina.stdlib.websubhub.Constants.PANIC_FROM_THE_SERVICE_ERROR;
+import static io.ballerina.stdlib.websubhub.Constants.SERVICE_EXECUTION_ERROR;
+import static io.ballerina.stdlib.websubhub.Constants.STATUS_CODE;
 
 /**
  * {@code HubCallback} used to handle the websubhub remote method invocation results.
@@ -56,8 +64,10 @@ public class HubCallback implements Callback {
     public void notifyFailure(BError bError) {
         bError.printStackTrace();
         BString errorMessage = fromString("service method invocation failed: " + bError.getErrorMessage());
-        BError invocationError = ErrorCreator.createError(module, "ServiceExecutionError",
-                errorMessage, bError, null);
+        BMap<BString, Object> errorDetails = ValueCreator.createRecordValue(module, COMMON_RESPONSE,
+                    Map.of(STATUS_CODE, PANIC_FROM_THE_SERVICE_ERROR));
+        BError invocationError = ErrorCreator.createError(module, SERVICE_EXECUTION_ERROR,
+                errorMessage, bError, errorDetails);
         future.complete(invocationError);
     }
 


### PR DESCRIPTION
## Purpose
> $subject

Fixes: [#4217](https://github.com/ballerina-platform/ballerina-standard-library/issues/4217)

## Examples
N/A

## Checklist
- [X] Linked to an issue
- [X] Updated the changelog
- [ ] Added tests
- [ ] Updated the spec
- [ ] Checked native-image compatibility
