### PR TITLE
[2201.7.x] [Fix] Additional parameters sent in the subscription request is not properly propagated into the `websubhub:VerifiedSubscription` message

### DIFF
--- a/ballerina/Dependencies.toml
+++ b/ballerina/Dependencies.toml
@@ -5,7 +5,7 @@
 
 [ballerina]
 dependencies-toml-version = "2"
-distribution-version = "2201.8.0-20230726-145300-b2bdf796"
+distribution-version = "2201.8.0-20230908-135700-74a59dff"
 
 [[package]]
 org = "ballerina"

--- a/ballerina/subscription.bal
+++ b/ballerina/subscription.bal
@@ -99,12 +99,7 @@ isolated function processSubscriptionVerification(http:Headers headers, HttpToWe
         string respStringPayload = check subscriberResponse.getTextPayload();
         if (respStringPayload == challenge) {
             VerifiedSubscription verifiedMessage = {
-                hub: message.hub,
-                hubMode: message.hubMode,
-                hubCallback: message.hubCallback,
-                hubTopic: message.hubTopic,
-                hubLeaseSeconds: message.hubLeaseSeconds,
-                hubSecret: message.hubSecret
+                ...message
             };
             check adaptor.callOnSubscriptionIntentVerifiedMethod(verifiedMessage, headers);
         }
@@ -186,10 +181,7 @@ isolated function processUnSubscriptionVerification(http:Headers headers, HttpTo
         string respStringPayload = check subscriberResponse.getTextPayload();
         if (respStringPayload == challenge) {
             VerifiedUnsubscription verifiedMessage = {
-                hubMode: message.hubMode,
-                hubCallback: message.hubCallback,
-                hubTopic: message.hubTopic,
-                hubSecret: message.hubSecret
+                ...message
             };
             check adaptor.callOnUnsubscriptionIntentVerifiedMethod(verifiedMessage, headers);
         }

--- a/changelog.md
+++ b/changelog.md
@@ -6,6 +6,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.9.1] - 2023-09-14
+
+### Fixed 
+- [Additional parameters sent in the subscription request is not properly propagated into the `websubhub:VerifiedSubscription` message](https://github.com/ballerina-platform/ballerina-standard-library/issues/4800)
+
 ## [1.5.1] - 2023-03-16
 
 ### Fixed


### PR DESCRIPTION
## Purpose
> $subject

Part of: [#4800](https://github.com/ballerina-platform/ballerina-standard-library/issues/4800)

## Examples
N/A

## Checklist
- [X] Linked to an issue
- [X] Updated the changelog
- [ ] ~Added tests~
- [ ] ~Updated the spec~
- [ ] Checked native-image compatibility
