### PR TITLE
[KafkaHub] Update publisher sample code with ability to provide payload as an env-variable

### DIFF
--- a/examples/kafka-hub/publisher/main.bal
+++ b/examples/kafka-hub/publisher/main.bal
@@ -18,7 +18,16 @@ import ballerina/websubhub;
 import ballerina/io;
 import ballerina/os;
 
-string topicName = os:getEnv("TOPIC_NAME") == "" ? "priceUpdate" : os:getEnv("TOPIC_NAME");
+json DEFAULT_PAYLOAD = {
+    itemName: string `Panasonic 32" LED TV`,
+    itemCode: "ITM30029",
+    previousPrice: 32999.00,
+    newPrice: 28999.00,
+    currencyCode: "SEK"
+};
+
+final string topicName = os:getEnv("TOPIC_NAME") == "" ? "priceUpdate" : os:getEnv("TOPIC_NAME");
+final json payload = os:getEnv("PAYLOAD") == "" ? DEFAULT_PAYLOAD: check os:getEnv("PAYLOAD").fromJsonString();
 
 type OAuth2Config record {|
     string tokenUrl;
@@ -49,13 +58,6 @@ public function main() returns error? {
             cert: "./resources/server.crt"
         }
     );
-    json params = {
-        itemName: string `Panasonic 32" LED TV`,
-        itemCode: "ITM30029",
-        previousPrice: 32999.00,
-        newPrice: 28999.00,
-        currencyCode: "SEK"
-    };
-    websubhub:Acknowledgement response = check websubHubClientEP->publishUpdate(topicName, params);
+    websubhub:Acknowledgement response = check websubHubClientEP->publishUpdate(topicName, payload);
     io:println("Receieved content-publish result: ", response);
 }


### PR DESCRIPTION
## Purpose
> $subject

## Examples
- Usage:
```sh
docker run --rm --network host --name websub-publisher -e TOPIC_NAME="sample-topic" -e PAYLOAD='{"itemName":"Panasonic Trimmer","itemCode":"ITM30030","previousPrice":5000.00,"newPrice":4500.00,"currencyCode":"SEK"}' ayeshalmeida/wbsbpublisher:3.0.0
```

## Checklist
- [ ] Linked to an issue
- [ ] Updated the changelog
- [ ] Added tests
- [ ] Updated the spec
- [ ] Checked native-image compatibility
