### PR TITLE
[KafkaHub] Update docker image versions for `hub` and `consolidator`

### DIFF
--- a/examples/kafka-hub/consolidator/Cloud.toml
+++ b/examples/kafka-hub/consolidator/Cloud.toml
@@ -1,7 +1,7 @@
 [container.image]
 repository="ballerina"
 name="consolidator"
-tag="6.0.0"
+tag="7.0.0"
 
 [[container.copy.files]]
 sourceFile="./resources"

--- a/examples/kafka-hub/docker-compose.yaml
+++ b/examples/kafka-hub/docker-compose.yaml
@@ -3,7 +3,7 @@ name: 'kafkahub'
 
 services:
     hub-1:
-        image: 'ayeshalmeida/kafkahub:8.0.0'
+        image: 'ayeshalmeida/kafkahub:9.0.0'
         hostname: hub1
         container_name: hub-1
         ports:
@@ -52,7 +52,7 @@ services:
             - hub_network
 
     consolidator: 
-        image: 'ayeshalmeida/consolidator:6.0.0'
+        image: 'ayeshalmeida/consolidator:7.0.0'
         hostname: consolidator
         container_name: consolidator
         ports:

--- a/examples/kafka-hub/hub/Cloud.toml
+++ b/examples/kafka-hub/hub/Cloud.toml
@@ -1,7 +1,7 @@
 [container.image]
 repository="ballerina"
 name="kafkahub"
-tag="8.0.0"
+tag="9.0.0"
 
 [[container.copy.files]]
 sourceFile="./resources"


### PR DESCRIPTION
## Purpose
> $subject

Part of: [#5916](https://github.com/ballerina-platform/ballerina-library/issues/5916)

## Examples
N/A

## Checklist
- [ ] Linked to an issue
- [ ] Updated the changelog
- [ ] Added tests
- [ ] Updated the spec
- [ ] Checked native-image compatibility
