### PR TITLE
Restructure kafka-consumer paritition-offset assignment logic

### DIFF
--- a/examples/kafka-hub/hub/modules/connections/connections.bal
+++ b/examples/kafka-hub/hub/modules/connections/connections.bal
@@ -142,7 +142,7 @@ public isolated function createMessageConsumer(string topicName, string groupNam
 
         if offset is kafka:PartitionOffset {
             kafka:Error? kafkaSeekErr = consumerEp->seek(offset);
-            if kafkaSeekErr is error {
+            if kafkaSeekErr is kafka:Error {
                 log:printError("Error occurred while assigning seeking partitions for the consumer", kafkaSeekErr);
                 return kafkaSeekErr;
             }

--- a/examples/kafka-hub/hub/modules/connections/connections.bal
+++ b/examples/kafka-hub/hub/modules/connections/connections.bal
@@ -130,8 +130,8 @@ public isolated function createMessageConsumer(string topicName, string groupNam
 
     kafka:TopicPartition[] parititionsWithoutCmtdOffsets = [];
     foreach kafka:TopicPartition partition in kafkaTopicPartitions {
-        kafka:PartitionOffset|error? offset = consumerEp->getCommittedOffset(partition);
-        if offset is error {
+        kafka:PartitionOffset|kafka:Error? offset = consumerEp->getCommittedOffset(partition);
+        if offset is kafka:Error {
             log:printError("Error occurred while retrieving the commited offsets for the topic-partition", offset);
             return offset;
         }
@@ -141,7 +141,7 @@ public isolated function createMessageConsumer(string topicName, string groupNam
         }
 
         if offset is kafka:PartitionOffset {
-            kafka:Error? kafkaSeekErr = check consumerEp->seek(offset);
+            kafka:Error? kafkaSeekErr = consumerEp->seek(offset);
             if kafkaSeekErr is error {
                 log:printError("Error occurred while assigning seeking partitions for the consumer", kafkaSeekErr);
                 return kafkaSeekErr;
@@ -150,8 +150,8 @@ public isolated function createMessageConsumer(string topicName, string groupNam
     }
 
     if parititionsWithoutCmtdOffsets.length() > 0 {
-        kafka:Error? kafkaSeekErr = check consumerEp->seekToBeginning(parititionsWithoutCmtdOffsets);
-        if kafkaSeekErr is error {
+        kafka:Error? kafkaSeekErr = consumerEp->seekToBeginning(parititionsWithoutCmtdOffsets);
+        if kafkaSeekErr is kafka:Error {
             log:printError("Error occurred while assigning seeking partitions (for paritions without committed offsets) for the consumer", kafkaSeekErr);
             return kafkaSeekErr;
         }

--- a/examples/kafka-hub/hub/modules/connections/connections.bal
+++ b/examples/kafka-hub/hub/modules/connections/connections.bal
@@ -115,7 +115,6 @@ public isolated function createMessageConsumer(string topicName, string groupNam
         return new (config:KAFKA_URL, consumerConfiguration);
     }
     
-    log:printInfo("Assigning kafka-topic partitions manually", details = partitions);
     kafka:Consumer|kafka:Error consumerEp = check new (config:KAFKA_URL, consumerConfiguration);
     if consumerEp is kafka:Error {
         log:printError("Error occurred while creating the consumer", consumerEp);
@@ -129,11 +128,33 @@ public isolated function createMessageConsumer(string topicName, string groupNam
         return paritionAssignmentErr;
     }
 
-    kafka:Error? kafkaSeekErr = consumerEp->seekToBeginning(kafkaTopicPartitions);
-    if kafkaSeekErr is kafka:Error {
-        log:printError("Error occurred while assigning seeking partitions for the consumer", paritionAssignmentErr);
-        return kafkaSeekErr;
+    kafka:TopicPartition[] parititionsWithoutCmtdOffsets = [];
+    foreach kafka:TopicPartition partition in kafkaTopicPartitions {
+        kafka:PartitionOffset|error? offset = consumerEp->getCommittedOffset(partition);
+        if offset is error {
+            log:printError("Error occurred while retrieving the commited offsets for the topic-partition", offset);
+            return offset;
+        }
+
+        if offset is () {
+            parititionsWithoutCmtdOffsets.push(partition);
+        }
+
+        if offset is kafka:PartitionOffset {
+            kafka:Error? kafkaSeekErr = check consumerEp->seek(offset);
+            if kafkaSeekErr is error {
+                log:printError("Error occurred while assigning seeking partitions for the consumer", kafkaSeekErr);
+                return kafkaSeekErr;
+            }
+        }
     }
 
+    if parititionsWithoutCmtdOffsets.length() > 0 {
+        kafka:Error? kafkaSeekErr = check consumerEp->seekToBeginning(parititionsWithoutCmtdOffsets);
+        if kafkaSeekErr is error {
+            log:printError("Error occurred while assigning seeking partitions (for paritions without committed offsets) for the consumer", kafkaSeekErr);
+            return kafkaSeekErr;
+        }
+    }
     return consumerEp;  
 }


### PR DESCRIPTION
## Purpose
> $subject

Related to: [#7376](https://github.com/ballerina-platform/ballerina-library/issues/7376)

## Examples
N/A

## Checklist
- [X] Linked to an issue
- [ ] ~Updated the changelog~
- [ ] ~Added tests~
- [ ] ~Updated the spec~
- [ ] ~Checked native-image compatibility~
