### PR TITLE
Introduce dynamic parameter order for the `websubhub:Service` remote methods

### DIFF
--- a/ballerina/Dependencies.toml
+++ b/ballerina/Dependencies.toml
@@ -73,7 +73,7 @@ dependencies = [
 [[package]]
 org = "ballerina"
 name = "http"
-version = "2.13.1"
+version = "2.13.2"
 dependencies = [
 	{org = "ballerina", name = "auth"},
 	{org = "ballerina", name = "cache"},

--- a/ballerina/tests/basic_hub_test.bal
+++ b/ballerina/tests/basic_hub_test.bal
@@ -24,7 +24,7 @@ listener Listener functionWithArgumentsListener = new(9090);
 
 service /websubhub on functionWithArgumentsListener {
 
-    isolated remote function onRegisterTopic(TopicRegistration message)
+    isolated remote function onRegisterTopic(TopicRegistration message, http:Headers headers)
                                 returns TopicRegistrationSuccess|TopicRegistrationError {
         if (message.topic == "test") {
             TopicRegistrationSuccess successResult = {
@@ -38,7 +38,7 @@ service /websubhub on functionWithArgumentsListener {
         }
     }
 
-    isolated remote function onDeregisterTopic(TopicDeregistration message)
+    isolated remote function onDeregisterTopic(TopicDeregistration message, http:Headers headers)
                         returns TopicDeregistrationSuccess|TopicDeregistrationError {
 
         map<string> body = { isDeregisterSuccess: "true" };
@@ -52,7 +52,7 @@ service /websubhub on functionWithArgumentsListener {
         }
     }
 
-    isolated remote function onUpdateMessage(UpdateMessage msg)
+    isolated remote function onUpdateMessage(UpdateMessage msg, http:Headers headers)
                returns Acknowledgement|UpdateMessageError {
         Acknowledgement ack = {};
         if (msg.hubTopic == "test") {

--- a/ballerina/tests/hub_authentication_test.bal
+++ b/ballerina/tests/hub_authentication_test.bal
@@ -39,7 +39,7 @@ final http:ListenerJwtAuthHandler handler = new({
 
 service /websubhub on securedListener {
 
-    remote function onRegisterTopic(TopicRegistration message, http:Headers headers)
+    remote function onRegisterTopic(http:Headers headers, TopicRegistration message)
                                 returns TopicRegistrationSuccess|TopicRegistrationError {
         string? auth = doAuth(headers);
         if (auth is string) {
@@ -49,7 +49,7 @@ service /websubhub on securedListener {
         return TOPIC_REGISTRATION_SUCCESS;
     }
 
-    remote function onDeregisterTopic(TopicDeregistration message, http:Headers headers)
+    remote function onDeregisterTopic(http:Headers headers, TopicDeregistration message)
                         returns TopicDeregistrationSuccess|TopicDeregistrationError {
         string? auth = doAuth(headers);
         if (auth is string) {
@@ -59,7 +59,7 @@ service /websubhub on securedListener {
         return TOPIC_DEREGISTRATION_SUCCESS;
     }
 
-    remote function onUpdateMessage(UpdateMessage message, http:Headers headers)
+    remote function onUpdateMessage(http:Headers headers, UpdateMessage message)
                returns Acknowledgement|UpdateMessageError {
         string? auth = doAuth(headers);
         if (auth is string) {
@@ -69,7 +69,7 @@ service /websubhub on securedListener {
         return ACKNOWLEDGEMENT;
     }
     
-    remote function onSubscription(Subscription message, http:Headers headers)
+    remote function onSubscription(http:Headers headers, Subscription message)
                 returns SubscriptionAccepted|InternalSubscriptionError {
         string? auth = doAuth(headers);
         if (auth is string) {
@@ -82,7 +82,7 @@ service /websubhub on securedListener {
     isolated remote function onSubscriptionIntentVerified(VerifiedSubscription message) {
     }
 
-    remote function onUnsubscription(Unsubscription message, http:Headers headers)
+    remote function onUnsubscription(http:Headers headers, Unsubscription message)
                returns UnsubscriptionAccepted|InternalUnsubscriptionError {
         string? auth = doAuth(headers);
         if (auth is string) {

--- a/changelog.md
+++ b/changelog.md
@@ -6,6 +6,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+- [Introduce dynamic parameter order for the `websubhub:Service` remote methods](https://github.com/ballerina-platform/ballerina-library/issues/7600)
+
 ## [1.11.1] - 2024-11-22
 
 ### Changed

--- a/native/src/main/java/io/ballerina/stdlib/websubhub/Constants.java
+++ b/native/src/main/java/io/ballerina/stdlib/websubhub/Constants.java
@@ -25,7 +25,7 @@ public interface Constants {
     String PACKAGE_ORG = "ballerina";
     String PACKAGE_NAME = "websubhub";
 
-    String SERVICE_OBJECT = "WEBSUBHUB_SERVICE_OBJECT";
+    String NATIVE_HUB_SERVICE = "NATIVE_HUB_SERVICE";
 
     String ON_REGISTER_TOPIC = "onRegisterTopic";
     String ON_DEREGISTER_TOPIC = "onDeregisterTopic";
@@ -36,6 +36,8 @@ public interface Constants {
     String ON_UNSUBSCRIPTION = "onUnsubscription";
     String ON_UNSUBSCRIPTION_VALIDATION = "onUnsubscriptionValidation";
     String ON_UNSUBSCRIPTION_INTENT_VERIFIED = "onUnsubscriptionIntentVerified";
+
+    String HTTP_HEADERS_TYPE = "http:Headers";
 
     String COMMON_RESPONSE = "CommonResponse";
     String STATUS_CODE = "statusCode";

--- a/native/src/main/java/io/ballerina/stdlib/websubhub/InteropArgs.java
+++ b/native/src/main/java/io/ballerina/stdlib/websubhub/InteropArgs.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright (c) 2025, WSO2 LLC. (http://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package io.ballerina.stdlib.websubhub;
+
+import io.ballerina.runtime.api.types.Type;
+import io.ballerina.runtime.api.values.BMap;
+import io.ballerina.runtime.api.values.BObject;
+import io.ballerina.runtime.api.values.BString;
+
+import static io.ballerina.stdlib.websubhub.Constants.HTTP_HEADERS_TYPE;
+
+/**
+ * {@code InteropArgs} is a wrapper object which contains the parameters for inter-op calls.
+ */
+public class InteropArgs {
+    private final BMap<BString, Object> message;
+    private final BObject httpHeaders;
+
+    InteropArgs(BMap<BString, Object> message, BObject httpHeaders) {
+        this.message = message;
+        this.httpHeaders = httpHeaders;
+    }
+
+    public Object getMappingArg(Type argType) {
+        String argTypeName = argType.toString();
+        if (HTTP_HEADERS_TYPE.equals(argTypeName)) {
+            return httpHeaders;
+        }
+        return message;
+    }
+}

--- a/native/src/main/java/io/ballerina/stdlib/websubhub/NativeHttpToWebsubhubAdaptor.java
+++ b/native/src/main/java/io/ballerina/stdlib/websubhub/NativeHttpToWebsubhubAdaptor.java
@@ -35,7 +35,6 @@ import io.ballerina.runtime.api.values.BMap;
 import io.ballerina.runtime.api.values.BObject;
 import io.ballerina.runtime.api.values.BString;
 
-import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
 
@@ -48,7 +47,7 @@ import static io.ballerina.stdlib.websubhub.Constants.ON_UNSUBSCRIPTION;
 import static io.ballerina.stdlib.websubhub.Constants.ON_UNSUBSCRIPTION_INTENT_VERIFIED;
 import static io.ballerina.stdlib.websubhub.Constants.ON_UNSUBSCRIPTION_VALIDATION;
 import static io.ballerina.stdlib.websubhub.Constants.ON_UPDATE_MESSAGE;
-import static io.ballerina.stdlib.websubhub.Constants.SERVICE_OBJECT;
+import static io.ballerina.stdlib.websubhub.Constants.NATIVE_HUB_SERVICE;
 
 /**
  * {@code NativeHttpToWebsubhubAdaptor} is a wrapper object used for service method execution.
@@ -57,87 +56,90 @@ public final class NativeHttpToWebsubhubAdaptor {
     private NativeHttpToWebsubhubAdaptor() {}
 
     public static void externInit(BObject adaptor, BObject serviceObj) {
-        adaptor.addNativeData(SERVICE_OBJECT, serviceObj);
+        adaptor.addNativeData(NATIVE_HUB_SERVICE, new NativeHubService(serviceObj));
     }
 
     public static BArray getServiceMethodNames(BObject adaptor) {
-        BObject bHubService = (BObject) adaptor.getNativeData(SERVICE_OBJECT);
-        List<BString> methodNamesList = new ArrayList<>();
-        ObjectType serviceType = (ObjectType) TypeUtils.getReferredType(TypeUtils.getType(bHubService));
-        for (MethodType method : serviceType.getMethods()) {
-            methodNamesList.add(StringUtils.fromString(method.getName()));
-        }
-        return ValueCreator.createArrayValue(methodNamesList.toArray(BString[]::new));
+        NativeHubService nativeHubService = (NativeHubService) adaptor.getNativeData(NATIVE_HUB_SERVICE);
+        List<BString> remoteMethodNames = nativeHubService.getRemoteMethodNames().stream()
+                .map(StringUtils::fromString).toList();
+        return ValueCreator.createArrayValue(remoteMethodNames.toArray(BString[]::new));
     }
 
     public static Object callRegisterMethod(Environment env, BObject adaptor,
                                             BMap<BString, Object> message, BObject bHttpHeaders) {
-        BObject bHubService = (BObject) adaptor.getNativeData(SERVICE_OBJECT);
+        NativeHubService nativeHubService = (NativeHubService) adaptor.getNativeData(NATIVE_HUB_SERVICE);
+        BObject bHubService = nativeHubService.getBHubService();
         boolean isReadOnly = isReadOnlyParam(bHubService, ON_REGISTER_TOPIC);
         if (isReadOnly) {
             message.freezeDirect();
         }
-        Object[] args = new Object[]{message, bHttpHeaders};
+        Object[] args = nativeHubService.getMethodArgs(ON_REGISTER_TOPIC, message, bHttpHeaders);
         return invokeRemoteFunction(env, bHubService, args,
                 "callRegisterMethod", ON_REGISTER_TOPIC);
     }
 
     public static Object callDeregisterMethod(Environment env, BObject adaptor,
                                               BMap<BString, Object> message, BObject bHttpHeaders) {
-        BObject bHubService = (BObject) adaptor.getNativeData(SERVICE_OBJECT);
+        NativeHubService nativeHubService = (NativeHubService) adaptor.getNativeData(NATIVE_HUB_SERVICE);
+        BObject bHubService = nativeHubService.getBHubService();
         boolean isReadOnly = isReadOnlyParam(bHubService, ON_DEREGISTER_TOPIC);
         if (isReadOnly) {
             message.freezeDirect();
         }
-        Object[] args = new Object[]{message, bHttpHeaders};
+        Object[] args = nativeHubService.getMethodArgs(ON_DEREGISTER_TOPIC, message, bHttpHeaders);
         return invokeRemoteFunction(env, bHubService, args,
                 "callDeregisterMethod", ON_DEREGISTER_TOPIC);
     }
 
     public static Object callOnUpdateMethod(Environment env, BObject adaptor,
                                             BMap<BString, Object> message, BObject bHttpHeaders) {
-        BObject bHubService = (BObject) adaptor.getNativeData(SERVICE_OBJECT);
+        NativeHubService nativeHubService = (NativeHubService) adaptor.getNativeData(NATIVE_HUB_SERVICE);
+        BObject bHubService = nativeHubService.getBHubService();
         boolean isReadOnly = isReadOnlyParam(bHubService, ON_UPDATE_MESSAGE);
         if (isReadOnly) {
             message.freezeDirect();
         }
-        Object[] args = new Object[]{message, bHttpHeaders};
+        Object[] args = nativeHubService.getMethodArgs(ON_UPDATE_MESSAGE, message, bHttpHeaders);
         return invokeRemoteFunction(env, bHubService, args,
                 "callOnUpdateMethod", ON_UPDATE_MESSAGE);
     }
 
     public static Object callOnSubscriptionMethod(Environment env, BObject adaptor,
                                                   BMap<BString, Object> message, BObject bHttpHeaders) {
-        BObject bHubService = (BObject) adaptor.getNativeData(SERVICE_OBJECT);
+        NativeHubService nativeHubService = (NativeHubService) adaptor.getNativeData(NATIVE_HUB_SERVICE);
+        BObject bHubService = nativeHubService.getBHubService();
         boolean isReadOnly = isReadOnlyParam(bHubService, ON_SUBSCRIPTION);
         if (isReadOnly) {
             message.freezeDirect();
         }
-        Object[] args = new Object[]{message, bHttpHeaders};
+        Object[] args = nativeHubService.getMethodArgs(ON_SUBSCRIPTION, message, bHttpHeaders);
         return invokeRemoteFunction(env, bHubService, args,
                 "callOnSubscriptionMethod", ON_SUBSCRIPTION);
     }
 
     public static Object callOnSubscriptionValidationMethod(Environment env, BObject adaptor,
                                                             BMap<BString, Object> message, BObject bHttpHeaders) {
-        BObject bHubService = (BObject) adaptor.getNativeData(SERVICE_OBJECT);
+        NativeHubService nativeHubService = (NativeHubService) adaptor.getNativeData(NATIVE_HUB_SERVICE);
+        BObject bHubService = nativeHubService.getBHubService();
         boolean isReadOnly = isReadOnlyParam(bHubService, ON_SUBSCRIPTION_VALIDATION);
         if (isReadOnly) {
             message.freezeDirect();
         }
-        Object[] args = new Object[]{message, bHttpHeaders};
+        Object[] args = nativeHubService.getMethodArgs(ON_SUBSCRIPTION_VALIDATION, message, bHttpHeaders);
         return invokeRemoteFunction(env, bHubService, args,
                 "callOnSubscriptionValidationMethod", ON_SUBSCRIPTION_VALIDATION);
     }
 
     public static Object callOnSubscriptionIntentVerifiedMethod(Environment env, BObject adaptor,
                                                                 BMap<BString, Object> message, BObject bHttpHeaders) {
-        BObject bHubService = (BObject) adaptor.getNativeData(SERVICE_OBJECT);
+        NativeHubService nativeHubService = (NativeHubService) adaptor.getNativeData(NATIVE_HUB_SERVICE);
+        BObject bHubService = nativeHubService.getBHubService();
         boolean isReadOnly = isReadOnlyParam(bHubService, ON_SUBSCRIPTION_INTENT_VERIFIED);
         if (isReadOnly) {
             message.freezeDirect();
         }
-        Object[] args = new Object[]{message, bHttpHeaders};
+        Object[] args = nativeHubService.getMethodArgs(ON_SUBSCRIPTION_INTENT_VERIFIED, message, bHttpHeaders);
         return invokeRemoteFunction(env, bHubService, args,
                 "callOnSubscriptionIntentVerifiedMethod",
                 ON_SUBSCRIPTION_INTENT_VERIFIED);
@@ -145,36 +147,39 @@ public final class NativeHttpToWebsubhubAdaptor {
 
     public static Object callOnUnsubscriptionMethod(Environment env, BObject adaptor,
                                                     BMap<BString, Object> message, BObject bHttpHeaders) {
-        BObject bHubService = (BObject) adaptor.getNativeData(SERVICE_OBJECT);
+        NativeHubService nativeHubService = (NativeHubService) adaptor.getNativeData(NATIVE_HUB_SERVICE);
+        BObject bHubService = nativeHubService.getBHubService();
         boolean isReadOnly = isReadOnlyParam(bHubService, ON_UNSUBSCRIPTION);
         if (isReadOnly) {
             message.freezeDirect();
         }
-        Object[] args = new Object[]{message, bHttpHeaders};
+        Object[] args = nativeHubService.getMethodArgs(ON_UNSUBSCRIPTION, message, bHttpHeaders);
         return invokeRemoteFunction(env, bHubService, args,
                 "callOnUnsubscriptionMethod", ON_UNSUBSCRIPTION);
     }
 
     public static Object callOnUnsubscriptionValidationMethod(Environment env, BObject adaptor,
                                                               BMap<BString, Object> message, BObject bHttpHeaders) {
-        BObject bHubService = (BObject) adaptor.getNativeData(SERVICE_OBJECT);
+        NativeHubService nativeHubService = (NativeHubService) adaptor.getNativeData(NATIVE_HUB_SERVICE);
+        BObject bHubService = nativeHubService.getBHubService();
         boolean isReadOnly = isReadOnlyParam(bHubService, ON_UNSUBSCRIPTION_VALIDATION);
         if (isReadOnly) {
             message.freezeDirect();
         }
-        Object[] args = new Object[]{message, bHttpHeaders};
+        Object[] args = nativeHubService.getMethodArgs(ON_UNSUBSCRIPTION_VALIDATION, message, bHttpHeaders);
         return invokeRemoteFunction(env, bHubService, args, "callOnUnsubscriptionValidationMethod",
                 ON_UNSUBSCRIPTION_VALIDATION);
     }
 
     public static Object callOnUnsubscriptionIntentVerifiedMethod(Environment env, BObject adaptor,
                                                                   BMap<BString, Object> message, BObject bHttpHeaders) {
-        BObject bHubService = (BObject) adaptor.getNativeData(SERVICE_OBJECT);
+        NativeHubService nativeHubService = (NativeHubService) adaptor.getNativeData(NATIVE_HUB_SERVICE);
+        BObject bHubService = nativeHubService.getBHubService();
         boolean isReadOnly = isReadOnlyParam(bHubService, ON_UNSUBSCRIPTION_INTENT_VERIFIED);
         if (isReadOnly) {
             message.freezeDirect();
         }
-        Object[] args = new Object[]{message, bHttpHeaders};
+        Object[] args = nativeHubService.getMethodArgs(ON_UNSUBSCRIPTION_INTENT_VERIFIED, message, bHttpHeaders);
         return invokeRemoteFunction(env, bHubService, args, "callOnUnsubscriptionIntentVerifiedMethod",
                 ON_UNSUBSCRIPTION_INTENT_VERIFIED);
     }

--- a/native/src/main/java/io/ballerina/stdlib/websubhub/NativeHttpToWebsubhubAdaptor.java
+++ b/native/src/main/java/io/ballerina/stdlib/websubhub/NativeHttpToWebsubhubAdaptor.java
@@ -74,7 +74,7 @@ public final class NativeHttpToWebsubhubAdaptor {
         if (isReadOnly) {
             message.freezeDirect();
         }
-        Object[] args = nativeHubService.getMethodArgs(ON_REGISTER_TOPIC, message, bHttpHeaders);
+        Object[] args = nativeHubService.getMethodArgs(ON_REGISTER_TOPIC, new InteropArgs(message, bHttpHeaders));
         return invokeRemoteFunction(env, bHubService, args,
                 "callRegisterMethod", ON_REGISTER_TOPIC);
     }
@@ -87,7 +87,7 @@ public final class NativeHttpToWebsubhubAdaptor {
         if (isReadOnly) {
             message.freezeDirect();
         }
-        Object[] args = nativeHubService.getMethodArgs(ON_DEREGISTER_TOPIC, message, bHttpHeaders);
+        Object[] args = nativeHubService.getMethodArgs(ON_DEREGISTER_TOPIC, new InteropArgs(message, bHttpHeaders));
         return invokeRemoteFunction(env, bHubService, args,
                 "callDeregisterMethod", ON_DEREGISTER_TOPIC);
     }
@@ -100,7 +100,7 @@ public final class NativeHttpToWebsubhubAdaptor {
         if (isReadOnly) {
             message.freezeDirect();
         }
-        Object[] args = nativeHubService.getMethodArgs(ON_UPDATE_MESSAGE, message, bHttpHeaders);
+        Object[] args = nativeHubService.getMethodArgs(ON_UPDATE_MESSAGE, new InteropArgs(message, bHttpHeaders));
         return invokeRemoteFunction(env, bHubService, args,
                 "callOnUpdateMethod", ON_UPDATE_MESSAGE);
     }
@@ -113,7 +113,7 @@ public final class NativeHttpToWebsubhubAdaptor {
         if (isReadOnly) {
             message.freezeDirect();
         }
-        Object[] args = nativeHubService.getMethodArgs(ON_SUBSCRIPTION, message, bHttpHeaders);
+        Object[] args = nativeHubService.getMethodArgs(ON_SUBSCRIPTION, new InteropArgs(message, bHttpHeaders));
         return invokeRemoteFunction(env, bHubService, args,
                 "callOnSubscriptionMethod", ON_SUBSCRIPTION);
     }
@@ -126,7 +126,8 @@ public final class NativeHttpToWebsubhubAdaptor {
         if (isReadOnly) {
             message.freezeDirect();
         }
-        Object[] args = nativeHubService.getMethodArgs(ON_SUBSCRIPTION_VALIDATION, message, bHttpHeaders);
+        Object[] args = nativeHubService.getMethodArgs(ON_SUBSCRIPTION_VALIDATION,
+                new InteropArgs(message, bHttpHeaders));
         return invokeRemoteFunction(env, bHubService, args,
                 "callOnSubscriptionValidationMethod", ON_SUBSCRIPTION_VALIDATION);
     }
@@ -139,7 +140,8 @@ public final class NativeHttpToWebsubhubAdaptor {
         if (isReadOnly) {
             message.freezeDirect();
         }
-        Object[] args = nativeHubService.getMethodArgs(ON_SUBSCRIPTION_INTENT_VERIFIED, message, bHttpHeaders);
+        Object[] args = nativeHubService.getMethodArgs(ON_SUBSCRIPTION_INTENT_VERIFIED,
+                new InteropArgs(message, bHttpHeaders));
         return invokeRemoteFunction(env, bHubService, args,
                 "callOnSubscriptionIntentVerifiedMethod",
                 ON_SUBSCRIPTION_INTENT_VERIFIED);
@@ -153,7 +155,7 @@ public final class NativeHttpToWebsubhubAdaptor {
         if (isReadOnly) {
             message.freezeDirect();
         }
-        Object[] args = nativeHubService.getMethodArgs(ON_UNSUBSCRIPTION, message, bHttpHeaders);
+        Object[] args = nativeHubService.getMethodArgs(ON_UNSUBSCRIPTION, new InteropArgs(message, bHttpHeaders));
         return invokeRemoteFunction(env, bHubService, args,
                 "callOnUnsubscriptionMethod", ON_UNSUBSCRIPTION);
     }
@@ -166,7 +168,8 @@ public final class NativeHttpToWebsubhubAdaptor {
         if (isReadOnly) {
             message.freezeDirect();
         }
-        Object[] args = nativeHubService.getMethodArgs(ON_UNSUBSCRIPTION_VALIDATION, message, bHttpHeaders);
+        Object[] args = nativeHubService.getMethodArgs(ON_UNSUBSCRIPTION_VALIDATION,
+                new InteropArgs(message, bHttpHeaders));
         return invokeRemoteFunction(env, bHubService, args, "callOnUnsubscriptionValidationMethod",
                 ON_UNSUBSCRIPTION_VALIDATION);
     }
@@ -179,7 +182,8 @@ public final class NativeHttpToWebsubhubAdaptor {
         if (isReadOnly) {
             message.freezeDirect();
         }
-        Object[] args = nativeHubService.getMethodArgs(ON_UNSUBSCRIPTION_INTENT_VERIFIED, message, bHttpHeaders);
+        Object[] args = nativeHubService.getMethodArgs(ON_UNSUBSCRIPTION_INTENT_VERIFIED,
+                new InteropArgs(message, bHttpHeaders));
         return invokeRemoteFunction(env, bHubService, args, "callOnUnsubscriptionIntentVerifiedMethod",
                 ON_UNSUBSCRIPTION_INTENT_VERIFIED);
     }

--- a/native/src/main/java/io/ballerina/stdlib/websubhub/NativeHubService.java
+++ b/native/src/main/java/io/ballerina/stdlib/websubhub/NativeHubService.java
@@ -1,0 +1,79 @@
+/*
+ * Copyright (c) 2025, WSO2 LLC. (http://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package io.ballerina.stdlib.websubhub;
+
+import io.ballerina.runtime.api.types.RemoteMethodType;
+import io.ballerina.runtime.api.types.ServiceType;
+import io.ballerina.runtime.api.types.Type;
+import io.ballerina.runtime.api.utils.TypeUtils;
+import io.ballerina.runtime.api.values.BMap;
+import io.ballerina.runtime.api.values.BObject;
+import io.ballerina.runtime.api.values.BString;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Stream;
+
+import static io.ballerina.stdlib.websubhub.Constants.HTTP_HEADERS_TYPE;
+
+/**
+ * {@code NativeBHubService} is a Java wrapper for Ballerina `websubhub:Service` object.
+ */
+public class NativeHubService {
+    private final BObject bHubService;
+    private final List<String> remoteMethodNames = new ArrayList<>();
+    private final Map<String, List<Type>> methodParameterMapping = new HashMap<>();
+
+
+    NativeHubService(BObject bHubService) {
+        RemoteMethodType[] remoteMethods = ((ServiceType) TypeUtils.getType(bHubService)).getRemoteMethods();
+        for (RemoteMethodType remoteMethod: remoteMethods) {
+            String methodName = remoteMethod.getName();
+            List<Type> paramTypeInOrder = Stream.of(remoteMethod.getParameters()).map(p -> p.type).toList();
+            methodParameterMapping.put(methodName, paramTypeInOrder);
+            remoteMethodNames.add(methodName);
+        }
+        this.bHubService = bHubService;
+    }
+
+    public BObject getBHubService() {
+        return bHubService;
+    }
+
+    public List<String> getRemoteMethodNames() {
+        return remoteMethodNames;
+    }
+
+    public Object[] getMethodArgs(String methodName, BMap<BString, Object> message, BObject bHttpHeaders) {
+        return methodParameterMapping.getOrDefault(methodName, Collections.emptyList()).stream()
+                .map(argType -> getMappingArg(argType, message, bHttpHeaders))
+                .toArray();
+    }
+
+    private Object getMappingArg(Type argType, BMap<BString, Object> message, BObject bHttpHeaders) {
+        String argTypeName = argType.toString();
+        if (HTTP_HEADERS_TYPE.equals(argTypeName)) {
+            return bHttpHeaders;
+        }
+        return message;
+    }
+}

--- a/native/src/main/java/io/ballerina/stdlib/websubhub/NativeHubService.java
+++ b/native/src/main/java/io/ballerina/stdlib/websubhub/NativeHubService.java
@@ -22,25 +22,20 @@ import io.ballerina.runtime.api.types.RemoteMethodType;
 import io.ballerina.runtime.api.types.ServiceType;
 import io.ballerina.runtime.api.types.Type;
 import io.ballerina.runtime.api.utils.TypeUtils;
-import io.ballerina.runtime.api.values.BMap;
 import io.ballerina.runtime.api.values.BObject;
-import io.ballerina.runtime.api.values.BString;
 
-import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.stream.Stream;
-
-import static io.ballerina.stdlib.websubhub.Constants.HTTP_HEADERS_TYPE;
 
 /**
  * {@code NativeBHubService} is a Java wrapper for Ballerina `websubhub:Service` object.
  */
 public class NativeHubService {
     private final BObject bHubService;
-    private final List<String> remoteMethodNames = new ArrayList<>();
     private final Map<String, List<Type>> methodParameterMapping = new HashMap<>();
 
 
@@ -50,7 +45,6 @@ public class NativeHubService {
             String methodName = remoteMethod.getName();
             List<Type> paramTypeInOrder = Stream.of(remoteMethod.getParameters()).map(p -> p.type).toList();
             methodParameterMapping.put(methodName, paramTypeInOrder);
-            remoteMethodNames.add(methodName);
         }
         this.bHubService = bHubService;
     }
@@ -59,21 +53,13 @@ public class NativeHubService {
         return bHubService;
     }
 
-    public List<String> getRemoteMethodNames() {
-        return remoteMethodNames;
+    public Set<String> getRemoteMethodNames() {
+        return methodParameterMapping.keySet();
     }
 
-    public Object[] getMethodArgs(String methodName, BMap<BString, Object> message, BObject bHttpHeaders) {
+    public Object[] getMethodArgs(String methodName, InteropArgs args) {
         return methodParameterMapping.getOrDefault(methodName, Collections.emptyList()).stream()
-                .map(argType -> getMappingArg(argType, message, bHttpHeaders))
+                .map(args::getMappingArg)
                 .toArray();
-    }
-
-    private Object getMappingArg(Type argType, BMap<BString, Object> message, BObject bHttpHeaders) {
-        String argTypeName = argType.toString();
-        if (HTTP_HEADERS_TYPE.equals(argTypeName)) {
-            return bHttpHeaders;
-        }
-        return message;
     }
 }


### PR DESCRIPTION
## Purpose
> $subject

Fixes: [#7600](https://github.com/ballerina-platform/ballerina-library/issues/7600)

## Examples

Previously, `websubhub:Service` only supported a fixed parameter order:  

```ballerina
service /websubhub on securedListener {

    remote function onRegisterTopic(websubhub:TopicRegistration message, http:Headers headers)
                                returns websubhub:TopicRegistrationSuccess|websubhub:TopicRegistrationError {
        
        // logic to be executed
    }

    // other methods
}
```

With the latest update, parameter order in remote methods is now flexible. At runtime, parameters will be dynamically identified, allowing method signatures to be reordered. For example, the following is now valid:  

```ballerina
service /websubhub on securedListener {

    remote function onRegisterTopic(http:Headers headers, websubhub:TopicRegistration message)
                                returns websubhub:TopicRegistrationSuccess|websubhub:TopicRegistrationError {
        
        // logic to be executed
    }

    // other methods
}
```


## Checklist
- [X] Linked to an issue
- [X] Updated the changelog
- [X] Added tests
- [ ] ~Updated the spec~
- [X] Checked native-image compatibility
