### PR TITLE
Upgrade Gradle to 9.5.1 and Ballerina Gradle plugin to 4.0.0

### DIFF
--- a/ballerina/build.gradle
+++ b/ballerina/build.gradle
@@ -16,6 +16,13 @@
  */
 
 import org.apache.tools.ant.taskdefs.condition.Os
+import org.gradle.process.ExecOperations
+
+import javax.inject.Inject
+
+abstract class BallerinaExecHelper {
+    @Inject abstract ExecOperations getExecOperations()
+}
 
 plugins {
     id 'io.ballerina.plugin'
@@ -71,8 +78,9 @@ task updateTomlFiles {
 }
 
 task commitTomlFiles {
+    def execHelper = project.objects.newInstance(BallerinaExecHelper)
     doLast {
-        project.exec {
+        execHelper.execOperations.exec {
             ignoreExitValue true
             if (Os.isFamily(Os.FAMILY_WINDOWS)) {
                 commandLine 'cmd', '/c', "git commit -m \"[Automated] Update the native jar versions\" Ballerina.toml Dependencies.toml CompilerPlugin.toml"

--- a/build-config/checkstyle/build.gradle
+++ b/build-config/checkstyle/build.gradle
@@ -28,7 +28,7 @@ task downloadCheckstyleRuleFiles(type: Download) {
     ])
     overwrite false
     onlyIfNewer true
-    dest buildDir
+    dest layout.buildDirectory.get().asFile
 }
 
 jar {
@@ -39,10 +39,10 @@ clean {
     enabled = false
 }
 
-artifacts.add('default', file("$project.buildDir/checkstyle.xml")) {
+artifacts.add('default', layout.buildDirectory.file("checkstyle.xml")) {
     builtBy('downloadCheckstyleRuleFiles')
 }
 
-artifacts.add('default', file("$project.buildDir/suppressions.xml")) {
+artifacts.add('default', layout.buildDirectory.file("suppressions.xml")) {
     builtBy('downloadCheckstyleRuleFiles')
 }

--- a/build-config/checkstyle/build.gradle
+++ b/build-config/checkstyle/build.gradle
@@ -46,3 +46,5 @@ artifacts.add('default', layout.buildDirectory.file("checkstyle.xml")) {
 artifacts.add('default', layout.buildDirectory.file("suppressions.xml")) {
     builtBy('downloadCheckstyleRuleFiles')
 }
+
+test.mustRunAfter(downloadCheckstyleRuleFiles)

--- a/build.gradle
+++ b/build.gradle
@@ -27,6 +27,9 @@ allprojects {
     version = project.version
 
     apply plugin: 'jacoco'
+    jacoco {
+        toolVersion = jacocoVersion
+    }
     apply plugin: 'maven-publish'
 
     repositories {
@@ -112,7 +115,7 @@ release {
     }
 }
 
-task build {
+tasks.named('build') {
     dependsOn(':websubhub-native:build')
     dependsOn('websubhub-ballerina:build')
     dependsOn(':websubhub-compiler-plugin:build')

--- a/build.gradle
+++ b/build.gradle
@@ -115,11 +115,22 @@ release {
     }
 }
 
-tasks.named('build') {
-    dependsOn(':websubhub-native:build')
-    dependsOn('websubhub-ballerina:build')
-    dependsOn(':websubhub-compiler-plugin:build')
-    dependsOn(':websubhub-compiler-plugin-tests:build')
+if (tasks.names.contains('build')) {
+    tasks.named('build') {
+        dependsOn(':websubhub-native:build')
+        dependsOn('websubhub-ballerina:build')
+        dependsOn(':websubhub-compiler-plugin:build')
+        dependsOn(':websubhub-compiler-plugin-tests:build')
+
+    }
+} else {
+    tasks.register('build') {
+        dependsOn(':websubhub-native:build')
+        dependsOn('websubhub-ballerina:build')
+        dependsOn(':websubhub-compiler-plugin:build')
+        dependsOn(':websubhub-compiler-plugin-tests:build')
+
+    }
 }
 
 publishToMavenLocal.dependsOn build

--- a/compiler-plugin-tests/build.gradle
+++ b/compiler-plugin-tests/build.gradle
@@ -53,7 +53,7 @@ spotbugsTest {
     def SpotBugsEffort = classLoader.findLoadedClass("com.github.spotbugs.snom.Effort")
     effort = SpotBugsEffort.MAX
     reportLevel = SpotBugsConfidence.LOW
-    reportsDir = file("$project.buildDir/reports/spotbugs")
+    reportsDir = layout.buildDirectory.dir("reports/spotbugs")
     reports {
         html.enabled true
         text.enabled = true

--- a/compiler-plugin/build.gradle
+++ b/compiler-plugin/build.gradle
@@ -45,7 +45,7 @@ spotbugsMain {
     def SpotBugsEffort = classLoader.findLoadedClass("com.github.spotbugs.snom.Effort")
     effort = SpotBugsEffort.MAX
     reportLevel = SpotBugsConfidence.LOW
-    reportsDir = file("$project.buildDir/reports/spotbugs")
+    reportsDir = layout.buildDirectory.dir("reports/spotbugs")
     reports {
         html.enabled true
         text.enabled = true

--- a/examples/build.gradle
+++ b/examples/build.gradle
@@ -1,4 +1,11 @@
 import org.apache.tools.ant.taskdefs.condition.Os
+import org.gradle.process.ExecOperations
+
+import javax.inject.Inject
+
+abstract class BallerinaExecHelper {
+    @Inject abstract ExecOperations getExecOperations()
+}
 
 /*
  * Copyright (c) 2021, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
@@ -59,11 +66,12 @@ task copyPackageBala {
 }
 
 task buildExamples {
+    def execHelper = project.objects.newInstance(BallerinaExecHelper)
     doLast {
         def moduleVersion = "${project.version}".replace("-SNAPSHOT", "")
         examples.each { example ->
             try {
-                exec {
+                execHelper.execOperations.exec {
                     workingDir project.projectDir
                     if (Os.isFamily(Os.FAMILY_WINDOWS)) {
                         commandLine 'cmd', '/c', "${ballerinaDist}/bin/bal.bat build ${example} && exit %%ERRORLEVEL%%"

--- a/gradle.properties
+++ b/gradle.properties
@@ -2,15 +2,16 @@ org.gradle.caching=true
 group=io.ballerina.stdlib
 version=1.16.2-SNAPSHOT
 ballerinaLangVersion=2201.12.0
+jacocoVersion=0.8.14
 testngVersion=7.6.1
-ballerinaGradlePluginVersion=2.3.0
+ballerinaGradlePluginVersion=4.0.0
 gsonVersion=2.8.8
 
 checkstylePluginVersion=10.12.0
-spotbugsPluginVersion=6.0.18
+spotbugsPluginVersion=6.5.1
 shadowJarPluginVersion=8.1.1
 downloadPluginVersion=5.4.0
-releasePluginVersion=2.8.0
+releasePluginVersion=3.1.0
 
 # Direct Dependencies
 stdlibIoVersion=1.8.0

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,7 +1,8 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.11.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-9.5.1-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
+distributionSha256Sum=bafc141b619ad6350fd975fc903156dd5c151998cc8b058e8c1044ab5f7b031f

--- a/native/build.gradle
+++ b/native/build.gradle
@@ -47,7 +47,7 @@ spotbugsMain {
     def SpotBugsEffort = classLoader.findLoadedClass("com.github.spotbugs.snom.Effort")
     effort = SpotBugsEffort.MAX
     reportLevel = SpotBugsConfidence.LOW
-    reportsDir = file("$project.buildDir/reports/spotbugs")
+    reportsDir = layout.buildDirectory.dir("reports/spotbugs")
     reports {
         html.enabled true
         text.enabled = true

--- a/settings.gradle
+++ b/settings.gradle
@@ -29,7 +29,7 @@ pluginManagement {
 }
 
 plugins {
-    id "com.gradle.enterprise" version "3.13.2"
+    id "com.gradle.develocity" version "3.19.2"
 }
 
 rootProject.name = 'websubhub'
@@ -46,9 +46,9 @@ project(':websubhub-compiler-plugin').projectDir = file("compiler-plugin")
 project(':websubhub-ballerina').projectDir = file("ballerina")
 project(':websubhub-compiler-plugin-tests').projectDir = file("compiler-plugin-tests")
 
-gradleEnterprise {
+develocity {
     buildScan {
-        termsOfServiceUrl = 'https://gradle.com/terms-of-service'
-        termsOfServiceAgree = 'yes'
+        termsOfUseUrl = 'https://gradle.com/help/legal-terms-of-use'
+        termsOfUseAgree = 'yes'
     }
 }


### PR DESCRIPTION
## Summary
- Upgrade the Gradle wrapper to 9.5.1 (with distribution checksum) and the Ballerina Gradle plugin to 4.0.0, needed for Java 21/25 compatibility.
- Fix Gradle 9 breakage: `project.exec` calls now use an injected `ExecOperations`, `com.gradle.enterprise` is migrated to `com.gradle.develocity`, any `task build {}` redefinition is replaced with `tasks.named('build')`, and checkstyle's `build.gradle` drops the deprecated `buildDir` property.

## Test plan
- [x] `./gradlew clean build` passes locally on Gradle 9.5.1 with plugin 4.0.0


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
- Upgraded the Gradle wrapper to 9.5.1 with checksum verification.
- Updated the Ballerina Gradle plugin and supporting dependency versions for Java 21 and 25 compatibility.
- Migrated build scripts to Gradle 9 APIs, including `ExecOperations` and `layout.buildDirectory`.
- Updated build task configuration and added Checkstyle task ordering.
- Replaced Gradle Enterprise integration with Develocity.
- Verified the changes with `./gradlew clean build`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->